### PR TITLE
Do not overflow local buffer

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -1680,7 +1680,7 @@ int main(int argc, char *argv[]) {
        * Read from container stderr for any error and send it to parent
        * We send -1 as pid to signal to parent that create container has failed.
        */
-      num_read = read(masterfd_stderr, buf, BUF_SIZE);
+      num_read = read(masterfd_stderr, buf, BUF_SIZE - 1);
       if (num_read > 0) {
         buf[num_read] = '\0';
         write_sync_fd(sync_pipe_fd, -1, buf);


### PR DESCRIPTION
Do not use full width of buf, as we intend to assign

    buf[num_read] = '\0';

at the end of the buffer, afterwards. In case we have just read full BUF_SIZE,
we will write '\0' to a memory location that is outside of buf. This can be
referred to as CWE-119 although, it seems pretty harmless in this case.

Signed-off-by: Šimon Lukašík <isimluk@fedoraproject.org>