### PR TITLE
WIP DO NOT MERGE journald driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ all: bin/conmon
 src = $(wildcard *.c)
 obj = $(src:.c=.o)
 
-override LIBS += $(shell pkg-config --libs glib-2.0)
+override LIBS += $(shell pkg-config --libs glib-2.0 libsystemd)
 
 CFLAGS ?= -std=c99 -Os -Wall -Wextra
-override CFLAGS += $(shell pkg-config --cflags glib-2.0) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
+override CFLAGS += $(shell pkg-config --cflags glib-2.0 libsystemd) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
 
 bin/conmon:
 	mkdir -p bin

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -19,6 +19,7 @@
 #include <sys/un.h>
 #include <sys/wait.h>
 #include <syslog.h>
+#include <systemd/sd-journal.h>
 #include <termios.h>
 #include <unistd.h>
 
@@ -135,7 +136,8 @@ static GOptionEntry opt_entries[] = {
      "Additional arg to pass to the exit command.  Can be specified multiple "
      "times",
      NULL},
-    {"log-path", 'l', 0, G_OPTION_ARG_STRING, &opt_log_path, "Log file path",
+    {"log-path", 'l', 0, G_OPTION_ARG_STRING, &opt_log_path, "Log file path. "
+     "Can also be formatted <DRIVER>:<PATH> to use a different log driver (default is kubernetes log file format",
      NULL},
     {"timeout", 'T', 0, G_OPTION_ARG_INT, &opt_timeout, "Timeout in seconds",
      NULL},
@@ -275,6 +277,50 @@ static log_level_t parse_level(char *level_name) {
     return DEBUG_LEVEL;
   }
   nexitf("No such log level %s", level_name);
+}
+
+
+/* Different log drivers */
+typedef enum {
+  KUBERNETES_LOG_FILE,
+  JOURNALD,
+  INVALID,
+} log_driver_t;
+
+// global saving the log driver the user inputted
+static log_driver_t g_log_driver = INVALID;
+
+// global saving the log path to use if the log driver is kubernetes-log-file
+static char* g_log_path = NULL;
+
+// Value the user must input for each log driver
+static const char * const KUBERNETES_LOG_FILE_STRING = "kubernetes-log-file";
+static const char * const JOURNALD_FILE_STRING = "journald";
+
+/* parse_log_path branches on log driver type the user inputted.
+ * log_config will either be a ':' delimited string containing:
+ * <DRIVER_NAME>:<PATH_NAME> or <PATH_NAME>
+ * in the case of no colon, the driver will be kubernetes-log-file,
+ * in the case the log driver is 'journald', the <PATH_NAME> is ignored.
+ * exits with error if <DRIVER_NAME> isn't 'journald' or 'kubernetes-log-file'
+ */
+void parse_log_path(char *log_config) {
+  char * driver = strtok(log_config, ":");
+  char * path = strtok(NULL, ":");
+  // If no : was found, driver is the log path, and the driver is
+  // kubernetes-log-file, set variables appropriately
+  if (path == NULL) {
+    g_log_path = driver;
+    g_log_driver = KUBERNETES_LOG_FILE;
+  } else if (!strcmp(driver, KUBERNETES_LOG_FILE_STRING)) {
+    g_log_path = path;
+    g_log_driver = KUBERNETES_LOG_FILE;
+  } else if (!strcmp(driver, JOURNALD_FILE_STRING)) {
+    // If we are logging to journald, we can ignore the path
+    g_log_driver = JOURNALD;
+  } else {
+    nexitf("No such log driver %s", driver);
+  }
 }
 
 static ssize_t write_all(int fd, const void *buf, size_t count) {
@@ -419,21 +465,23 @@ const char *stdpipe_name(stdpipe_t pipe) {
  * reopen_log_file reopens the log file fd.
  */
 static void reopen_log_file(void) {
-  _cleanup_free_ char *opt_log_path_tmp =
-      g_strdup_printf("%s.tmp", opt_log_path);
+  if (g_log_path != NULL) {
+      _cleanup_free_ char *g_log_path_tmp =
+          g_strdup_printf("%s.tmp", g_log_path);
 
-  /* Close the current log_fd */
-  close(log_fd);
+      /* Close the current log_fd */
+      close(log_fd);
 
-  /* Open the log path file again */
-  log_fd =
-      open(opt_log_path_tmp, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC, 0600);
-  if (log_fd < 0)
-    pexitf("Failed to open log file %s", opt_log_path);
+      /* Open the log path file again */
+      log_fd =
+          open(g_log_path_tmp, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC, 0600);
+      if (log_fd < 0)
+        pexitf("Failed to open log file %s", g_log_path);
 
-  /* Replace the previous file */
-  if (rename(opt_log_path_tmp, opt_log_path) < 0) {
-    pexit("Failed to rename log file");
+      /* Replace the previous file */
+      if (rename(g_log_path_tmp, g_log_path) < 0) {
+        pexit("Failed to rename log file");
+      }
   }
 }
 
@@ -718,9 +766,10 @@ static gboolean tty_hup_timeout_cb(G_GNUC_UNUSED gpointer user_data) {
 }
 
 static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof) {
-  /* We use one extra byte at the start, which we don't read into, instead
-     we use that for marking the pipe when we write to the attached socket */
-  char real_buf[STDIO_BUF_SIZE + 1];
+  /* We use two extra bytes. One at the start, which we don't read into, instead
+     we use that for marking the pipe when we write to the attached socket.
+     One at the end to guarentee a null-terminated buffer for journald logging*/
+  char real_buf[STDIO_BUF_SIZE + 2];
   char *buf = real_buf + 1;
   ssize_t num_read = 0;
   size_t i;
@@ -737,9 +786,20 @@ static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof) {
     nwarnf("stdio_input read failed %s", strerror(errno));
     return false;
   } else {
-    if (write_k8s_log(log_fd, pipe, buf, num_read) < 0) {
-      nwarn("write_k8s_log failed");
-      return G_SOURCE_CONTINUE;
+    // Branch on log driver type to find where to write to
+    if (g_log_driver == JOURNALD) {
+      // Always null terminate the buffer, just in case.
+      buf[num_read] = '\0';
+      if (sd_journal_print(LOG_NOTICE, "%s", buf) < 0) {
+        nwarn("sd_journal_print failed");
+        return G_SOURCE_CONTINUE;
+      }
+    }
+    else if (g_log_driver == KUBERNETES_LOG_FILE) {
+      if (write_k8s_log(log_fd, pipe, buf, num_read) < 0) {
+        nwarn("write_k8s_log failed");
+        return G_SOURCE_CONTINUE;
+      }
     }
 
     if (conn_socks == NULL) {
@@ -1401,6 +1461,11 @@ int main(int argc, char *argv[]) {
   if (opt_log_path == NULL)
     nexit("Log file path not provided. Use --log-path");
 
+  // parse_log_path will call exit if the log driver isn't
+  // kubernetes-log-file, journald or NULL, so we set up g_log_driver to always
+  // have a logical value
+  parse_log_path(opt_log_path);
+
   start_pipe_fd = get_pipe_fd_from_env("_OCI_STARTPIPE");
   if (start_pipe_fd >= 0) {
     /* Block for an initial write to the start pipe before
@@ -1447,10 +1512,12 @@ int main(int argc, char *argv[]) {
   /* Environment variables */
   sync_pipe_fd = get_pipe_fd_from_env("_OCI_SYNCPIPE");
 
-  /* Open the log path file. */
-  log_fd = open(opt_log_path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0600);
-  if (log_fd < 0)
-    pexit("Failed to open log file");
+  if (g_log_driver == KUBERNETES_LOG_FILE) {
+      /* Open the log path file. */
+      log_fd = open(g_log_path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0600);
+      if (log_fd < 0)
+        pexit("Failed to open log file");
+  }
 
   /*
    * Set self as subreaper so we can wait for container process


### PR DESCRIPTION
Laid groundwork for journald log driver, including:
added a log-driver option to allow a user to branch on log driver type, as well as a function to parse it
log-driver defaults to file-json to maintain backwards compatibility.
if the log-driver is journald, write to output previously written with write_k8s_log to journald with C API.

TODO:
Currently, there is some weirdness with calling top in a container. It isn't necessarily a buffer overflow problem (as calling sh -c 'while true; do echo hello; done' doesn't cause the same crash). I could use some pointers on that.

need to hammer out when a log-file is needed and when it will be written to. If journald is enabled, should it get all of the output and report and error if the user also gives a log-file? Should it write to both?

Signed-off-by: Peter Hunt <pehunt@redhat.com>