### PR TITLE
Add Meson build configuration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,48 @@
+
+project('conmon', 'c',
+        version : '0.1',
+        license : 'Apache-2.0',
+        default_options : [
+                'c_std=c99',
+        ],
+        meson_version : '>= 0.46',
+)
+
+git_commit = ''
+
+git = find_program('git', required : false)
+if git.found()
+        git_commit = run_command(
+                git,
+                ['--git-dir=@0@/.git'.format(meson.source_root()),
+                 'rev-parse', 'HEAD']).stdout().strip()
+        git_dirty = run_command(
+                git,
+                ['--git-dir=@0@/.git'.format(meson.source_root()),
+                 'status', '--porcelain', '--untracked-files=no']).stdout().strip()
+        if git_dirty != ''
+                git_commit = git_commit + '-dirty'
+        endif
+endif
+
+conf = configuration_data()
+conf.set_quoted('VERSION', meson.project_version())
+conf.set_quoted('GIT_COMMIT', git_commit)
+
+add_project_arguments('-Os', '-Wall', '-Werror',
+                      '-DVERSION=' + conf.get('VERSION'),
+                      '-DGIT_COMMIT=' + conf.get('GIT_COMMIT'),
+                      language : 'c')
+
+glib = dependency('glib-2.0')
+
+executable('conmon',
+           ['src/conmon.c',
+            'src/config.h',
+            'src/cmsg.c',
+            'src/cmsg.h'],
+           dependencies : [glib],
+           install : true,
+           install_dir : join_paths(get_option('libexecdir'), 'podman'),
+)
+


### PR DESCRIPTION
Replace the rules in a Makefile with a Meson based build.

The build is essentially equivalent, except that the target directory for the conmon binary is `$(LIBEXECDIR)/podman` instead of `$(LIBEXECDIR)/crio`.

---

This is in some ways an alternative to #9 (even though merging both is probably fine.)

Getting it right on Makefiles is just too hard... Meson is much nicer. (If using `make`, at least adopting automake would make the Makefiles more reliable, but Meson is still a much cleaner approach!)

This is somewhat incomplete, since the `.rpmbuild/Makefile` and `*.spec.in` need updating, and the change needs a counterpart in the Fedora RPM for podman... But let me know your initial thoughts, I'd be happy to update those as well if you like the idea of adopting Meson.

Cheers,
Filipe
