### PR TITLE
Remove Makefile git shell commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-include Makefile.inc
-
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
-GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 VERSION := $(shell cat VERSION)
 PREFIX ?= ${DESTDIR}/usr/local
 BINDIR ?= ${PREFIX}/bin
@@ -9,8 +5,21 @@ LIBEXECDIR ?= ${PREFIX}/libexec
 MANDIR ?= ${PREFIX}/share/man
 ETCDIR ?= ${DESTDIR}/etc
 
-.PHONY: all
-all: bin bin/conmon
+.PHONY: all git-vars
+all: git-vars bin bin/conmon
+
+git-vars:
+ifneq ($(wildcard .git),)
+	$(eval COMMIT_NO :=$(shell git rev-parse HEAD 2> /dev/null || true))
+	$(eval GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}"))
+	$(eval GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))
+	$(eval GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g"))
+else
+	$(eval COMMIT_NO := unknown)
+	$(eval GIT_COMMIT := unknown)
+	$(eval GIT_BRANCH := unknown)
+	$(eval GIT_BRANCH_CLEAN := unknown)
+endif
 
 override LIBS += $(shell pkg-config --libs glib-2.0)
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,2 +1,0 @@
-COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
-GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")


### PR DESCRIPTION
The git commands leads into annoying failures when not running within a
git repository (only on downloaded sources). It should be fine to remove
them since they're not used anywhere.