### PR TITLE
Add podman and crio make target

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -97,7 +97,7 @@ fedora_packaging_task:
         - make -f .rpmbuild/Makefile
         - rpmbuild --rebuild conmon-*.src.rpm
         - dnf -y install ~/rpmbuild/RPMS/x86_64/conmon*.x86_64.rpm
-        - ls -l /usr/libexec/crio/conmon
+        - ls -l /usr/bin/conmon
 
     timeout_in: '20m'
 

--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,21 @@ clean:
 	rm -f bin/conmon src/*.o
 	rmdir bin
 
-.PHONY: install install.bin
+.PHONY: install install.bin install.crio install.podman podman crio
 install: install.bin
 
+podman: install.podman
+
+crio: install.crio
+
 install.bin: bin/conmon
+	install ${SELINUXOPT} -D -m 755 bin/conmon $(BINDIR)/conmon
+
+install.crio: bin/conmon
 	install ${SELINUXOPT} -D -m 755 bin/conmon $(LIBEXECDIR)/crio/conmon
+
+install.podman: bin/conmon
+	install ${SELINUXOPT} -D -m 755 bin/conmon $(LIBEXECDIR)/podman/conmon
 
 .PHONY: fmt
 fmt:

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -259,7 +259,7 @@ build_and_replace_conmon() {
 
     NEWNAME=.original_packaged_conmon
     echo "Renaming conmon binaries from RPMs"
-    find /usr/libexec -type f -name conmon |
+    find /usr -type f -name conmon |
     while read CONMON_FILEPATH
     do
         NEWPATH="$(dirname $CONMON_FILEPATH)/$NEWNAME"
@@ -271,8 +271,8 @@ build_and_replace_conmon() {
 
     ooe.sh make
     echo "Installing conmon"
-    ooe.sh sudo make install PREFIX=/usr
+    ooe.sh sudo make crio PREFIX=/usr
     # Use same version for podman in case ever needed
     ooe.sh sudo ln -fv /usr/libexec/crio/conmon /usr/libexec/podman/conmon
-    ooe.sh sudo restorecon -R /usr/libexec
+    ooe.sh sudo restorecon -R /usr/bin
 }

--- a/contrib/spec/conmon.spec.in
+++ b/contrib/spec/conmon.spec.in
@@ -45,7 +45,7 @@ BuildRequires: pkgconfig
 %files
 %license LICENSE
 %doc README.md
-%{_libexecdir}/crio/%{name}
+%{_usr}/bin/%{name}
 
 %changelog
 * Mon Oct 01 2018 Lokesh Mandvekar <lsm5@fedoraproject.org> - 0-0.1.gite7805e2


### PR DESCRIPTION
Users can now directly install to a "podman" directory, instead of needing to install to crio, then link to podman

Signed-off-by: Peter Hunt <pehunt@redhat.com>