### PR TITLE
Add warning if read events failed

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -572,7 +572,10 @@ static gboolean oom_cb_cgroup_v2(int fd, GIOCondition condition, G_GNUC_UNUSED g
 	gboolean ret = G_SOURCE_REMOVE;
 
 	/* Drop the inotify events.  */
-	read(fd, &events, sizeof(events));
+	ssize_t num_read = read(fd, &events, sizeof(events));
+	if (num_read < 0) {
+		pwarn("Failed to read events");
+	}
 
 	if ((condition & G_IO_IN) != 0) {
 		ret = check_cgroup2_oom();


### PR DESCRIPTION
We now add a warning if the read of events fd failed. This also fixes a warning that the return value of `read` is not considered in that place.