### PR TITLE
Add cmd/config/config.go

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,9 +20,11 @@ env:
     TRAVIS: "true"
 
     ####
-    #### Cache-image names to test with
+    #### Image names to test with
     ###
     FEDORA_CACHE_IMAGE_NAME: 'fedora-29-conmon-75ea13be'
+    FEDORA_CONTAINER_FQIN: 'registry.fedoraproject.org/fedora:29'
+    PRIOR_FEDORA_CONTAINER_FQIN: 'registry.fedoraproject.org/fedora:28'
 
     ####
     #### Variables for composing new cache-images (used in PR testing) from
@@ -63,6 +65,9 @@ timeout_in: '120m'
 # testing for every platform
 integration_task:
 
+    depends_on:
+        - 'config'
+
     gce_instance:
         # Generate multiple parallel tasks, covering all possible
         # 'matrix' combinations.
@@ -85,8 +90,8 @@ fedora_packaging_task:
     # Runs within Cirrus's "community cluster"
     container:
         matrix:
-            image: "registry.fedoraproject.org/fedora:28"
-            image: "registry.fedoraproject.org/fedora:29"
+            image: "${FEDORA_CONTAINER_FQIN}"
+            image: "${PRIOR_FEDORA_CONTAINER_FQIN}"
         cpu: 4
         memory: 12
 
@@ -101,6 +106,26 @@ fedora_packaging_task:
 
     timeout_in: '20m'
 
+# Verify calls to bin/config were saved
+config_task:
+    env:
+        GOSRC: $CIRRUS_WORKING_DIR
+    # Runs within Cirrus's "community cluster"
+    container:
+        matrix:
+               # fedora:28 doesn't have go mod by default
+               # and we should only need one check to make sure
+               # config changes were synced
+            image: "${FEDORA_CONTAINER_FQIN}"
+        cpu: 4
+        memory: 12
+
+    script:
+        - dnf install -y make glib2-devel git gcc rpm-build golang
+        - cd $CIRRUS_WORKING_DIR
+        - GO111MODULE=on go mod init github.com/containers/conmon
+        - make config
+        - ./hack/tree_status.sh
 
 # Test building of new cache-images for future PR testing, in this PR.
 # Output images will be stored only for a very short time, then automaticly deleted.

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+bin/

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ VERSION := $(shell cat VERSION)
 PREFIX ?= /usr/local
 BINDIR ?= ${PREFIX}/bin
 LIBEXECDIR ?= ${PREFIX}/libexec
+GO ?= go
+PROJECT := github.com/containers/conmon
+
+
 
 .PHONY: all git-vars
 all: git-vars bin bin/conmon
@@ -43,6 +47,10 @@ bin/conmon: src/conmon.o src/cmsg.o src/ctr_logging.o src/utils.o | bin
 
 %.o: %.c
 	$(CC) $(CFLAGS) -o $@ -c $<
+
+config: git-vars cmd/conmon-config/conmon-config.go runner/config/config.go runner/config/config_unix.go runner/config/config_windows.go
+	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o bin/config $(PROJECT)/cmd/conmon-config
+		( cd src && $(CURDIR)/bin/config )
 
 src/cmsg.o: src/cmsg.c src/cmsg.h
 

--- a/cmd/conmon-config/conmon-config.go
+++ b/cmd/conmon-config/conmon-config.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/containers/conmon/runner/config"
+)
+
+func main() {
+	output := `
+#if !defined(CONFIG_H)
+#define CONFIG_H
+
+#define BUF_SIZE %d
+#define STDIO_BUF_SIZE %d
+#define DEFAULT_SOCKET_PATH "%s"
+
+#endif // CONFIG_H
+`
+	if err := ioutil.WriteFile("config.h", []byte(fmt.Sprintf(output, config.BufSize, config.BufSize, config.ContainerAttachSocketDir)), 0644); err != nil {
+		fmt.Errorf(err.Error())
+	}
+}

--- a/hack/tree_status.sh
+++ b/hack/tree_status.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# this script is based off of the similarly named in github.com/containers/libpod/hack/tree_status.sh
+
+set -e
+
+SUGGESTION="${SUGGESTION:-call 'make config' and commit all changes.}"
+
+STATUS=$(git status --porcelain)
+if [[ -z $STATUS ]]
+then
+	echo "tree is clean"
+else
+	echo "tree is dirty, please $SUGGESTION"
+	echo ""
+	echo "$STATUS"
+	exit 1
+fi

--- a/runner/config/config.go
+++ b/runner/config/config.go
@@ -1,0 +1,6 @@
+package config
+
+const (
+	// BufSize is the size of buffers passed in to sockets
+	BufSize = 8192
+)

--- a/runner/config/config_unix.go
+++ b/runner/config/config_unix.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package config
+
+const (
+	ContainerAttachSocketDir = "/var/run/crio"
+)

--- a/runner/config/config_windows.go
+++ b/runner/config/config_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package config
+
+const (
+	ContainerAttachSocketDir = "C:\\crio\\run\\"
+)


### PR DESCRIPTION
Now, we can configure conmon from within the conmon directory.

This will allow tools to vendor conmon and import the values they need, rather than having the configuration parameters in different repositories

This PR also comes with the eventual goal of coupling containers/conmon with the go code that calls it, so libraries that use conmon don't have to worry too much about conflicting versions

Signed-off-by: Peter Hunt <pehunt@redhat.com>