### PR TITLE
conmon: force unlink attach socket

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -845,6 +845,9 @@ static char *setup_attach_socket(void)
 	if (fchmod(attach_socket_fd, 0700))
 		pexit("Failed to change attach socket permissions");
 
+	if (unlink(attach_addr.sun_path) == -1 && errno != ENOENT)
+		pexitf("Failed to remove existing attach socket: %s", attach_addr.sun_path);
+
 	if (bind(attach_socket_fd, (struct sockaddr *)&attach_addr, sizeof(struct sockaddr_un)) == -1)
 		pexitf("Failed to bind attach socket: %s", attach_sock_path);
 


### PR DESCRIPTION
before we attempt to create the attach socket, make sure it doesn't
already exist otherwise bind(2) will fail with EEXIST.

Closes: https://github.com/containers/libpod/issues/3381

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>