### PR TITLE
Update git-vars target to check for executable as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PKG_CONFIG ?= pkg-config
 all: git-vars bin bin/conmon
 
 git-vars:
-ifneq ($(wildcard .git),)
+ifeq ($(shell bash -c '[[ `command -v git` && `git rev-parse --git-dir 2>/dev/null` ]] && echo true'),true)
 	$(eval COMMIT_NO :=$(shell git rev-parse HEAD 2> /dev/null || true))
 	$(eval GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}"))
 	$(eval GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))


### PR DESCRIPTION
If the `git` executable is not available then the `git-vars` Makefile
target will now cover that as well.

Side-port of: https://github.com/cri-o/cri-o/pull/2581