### PR TITLE
Makefile: don't fail if clean is called without a build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,7 @@ bin:
 
 .PHONY: clean
 clean:
-	rm -f bin/conmon src/*.o
-	rmdir bin
+	rm -rf bin/ src/*.o
 
 .PHONY: install install.bin install.crio install.podman podman crio
 install: install.bin


### PR DESCRIPTION
Do not fail when calling the clean target without building first.

Signed-off-by: Stefan Agner <stefan@agner.ch>