### PR TITLE
Add 'trace' log level support

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,6 @@
 #include "utils.h"
 #include <string.h>
+#include <strings.h>
 
 log_level_t log_level = WARN_LEVEL;
 char *log_cid = NULL;
@@ -14,18 +15,22 @@ void set_conmon_logs(char *level_name, char *cid_, gboolean syslog_)
 	// log_level is initialized as Warning, no need to set anything
 	if (level_name == NULL)
 		return;
-	if (!strcmp(level_name, "error") || !strcmp(level_name, "fatal") || !strcmp(level_name, "panic")) {
+	if (!strcasecmp(level_name, "error") || !strcasecmp(level_name, "fatal") || !strcasecmp(level_name, "panic")) {
 		log_level = EXIT_LEVEL;
 		return;
-	} else if (!strcmp(level_name, "warn") || !strcmp(level_name, "warning")) {
+	} else if (!strcasecmp(level_name, "warn") || !strcasecmp(level_name, "warning")) {
 		log_level = WARN_LEVEL;
 		return;
-	} else if (!strcmp(level_name, "info")) {
+	} else if (!strcasecmp(level_name, "info")) {
 		log_level = INFO_LEVEL;
 		return;
-	} else if (!strcmp(level_name, "debug")) {
+	} else if (!strcasecmp(level_name, "debug")) {
 		log_level = DEBUG_LEVEL;
 		return;
+	} else if (!strcasecmp(level_name, "trace")) {
+		log_level = TRACE_LEVEL;
+		return;
 	}
+	ntracef("set log level to %s", level_name);
 	nexitf("No such log level %s", level_name);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,6 +25,7 @@ typedef enum {
 	WARN_LEVEL,
 	INFO_LEVEL,
 	DEBUG_LEVEL,
+	TRACE_LEVEL,
 } log_level_t;
 
 // Default log level is Warning, This will be configured before any logging
@@ -131,6 +132,24 @@ extern gboolean use_syslog;
 			fprintf(stderr, "[conmon:d]: " fmt "\n", ##__VA_ARGS__); \
 			if (use_syslog) \
 				syslog(LOG_INFO, "conmon %.20s <ndebug>: " fmt " \n", log_cid, ##__VA_ARGS__); \
+		} while (0); \
+	}
+
+#define ntrace(s) \
+	if (log_level >= TRACE_LEVEL) { \
+		do { \
+			fprintf(stderr, "[conmon:d]: %s\n", s); \
+			if (use_syslog) \
+				syslog(LOG_INFO, "conmon %.20s <ntrace>: %s\n", log_cid, s); \
+		} while (0); \
+	}
+
+#define ntracef(fmt, ...) \
+	if (log_level >= TRACE_LEVEL) { \
+		do { \
+			fprintf(stderr, "[conmon:d]: " fmt "\n", ##__VA_ARGS__); \
+			if (use_syslog) \
+				syslog(LOG_INFO, "conmon %.20s <ntrace>: " fmt " \n", log_cid, ##__VA_ARGS__); \
 		} while (0); \
 	}
 


### PR DESCRIPTION
The trace log level is currently not supported by conmon, but seems to be
a valid level for container runtimes like CRI-O and podman. This results
that the container currently won't start if the log level is set to
'trace'. Beside this, we now case insensitively compare the log level
string to make it more fail safe.