### PR TITLE
Fix CRI-O regression on ReopenContainerLog requests

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -993,6 +993,7 @@ static int setup_terminal_control_fifo()
 	int dummyfd = open(ctl_fifo_path, O_WRONLY | O_CLOEXEC);
 	if (dummyfd == -1)
 		pexit("Failed to open dummy writer for fifo");
+	g_unix_fd_add(terminal_ctrl_fd, G_IO_IN, ctrl_cb, NULL);
 
 	ninfof("terminal_ctrl_fd: %d", terminal_ctrl_fd);
 	return dummyfd;


### PR DESCRIPTION
This critest conformance test fails with CRI-O using conmon releases >= 2.0.1:

https://github.com/kubernetes-sigs/cri-tools/blob/bc50b06dc86f5884d8bbb961fc0325652dbb6e1c/pkg/validate/container.go#L252-L258

The main issue is that when renaming the container log file, a request
to `ReopenContainerLog` will stuck until timed-out because the logfile
does not actually get renamed at all.

Fixing the issue by re-adding the call to `g_unix_fd_add` which has been
removed in 9e1e1ffc5488ee8ff53057a855f1bd5343895695.

---

Refers to: https://github.com/cri-o/cri-o/pull/2941
Log outputs: https://circleci.com/gh/openSUSE/cri-o/23622

After we'd agreed on the solution we could draft a new conmon release which is conformant with CRI-O 1.16 (unreleased)