### PR TITLE
conmon: kill the process group on timeout

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -1721,7 +1721,11 @@ int main(int argc, char *argv[])
 	const char *exit_message = NULL;
 
 	if (timed_out) {
-		if (container_pid > 0)
+		pid_t process_group = getpgid(container_pid);
+
+		if (process_group > 0)
+			kill(-process_group, SIGKILL);
+		else
 			kill(container_pid, SIGKILL);
 		exit_message = "command timed out";
 	} else {


### PR DESCRIPTION
when the timeout is expired, instead of killing the process, make sure
to kill the entire process group.

It is not safe as using pid cgroup or a pid namespace, which we cannot
use as the script must run inside of the container pid namespace, but
it addresses most common cases like bash forking a new process.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1774184

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>