### PR TITLE
Fixes format string to limit the size of the string to 10 characters

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -1566,7 +1566,7 @@ int main(int argc, char *argv[])
 			errno = 0;
 			int lpid = strtol(listenpid, NULL, 10);
 			if (errno != 0 || lpid <= 0)
-				pexitf("Invalid LISTEN_PID %10s", listenpid);
+				pexitf("Invalid LISTEN_PID %.10s", listenpid);
 			if (opt_replace_listen_pid || lpid == getppid()) {
 				gchar *pidstr = g_strdup_printf("%d", getpid());
 				if (!pidstr)


### PR DESCRIPTION
%10s just ensures that when printing, at least 10 characters are
written. However, in this case we probably want *at most* 10 characters
to be written.