### PR TITLE
conmon: chmod std files pipes

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -1547,16 +1547,22 @@ int main(int argc, char *argv[])
 			slavefd_stdin = dev_null_r;
 		if (dup2(slavefd_stdin, STDIN_FILENO) < 0)
 			pexit("Failed to dup over stdin");
+		if (fchmod(STDIN_FILENO, 0777) < 0)
+			nwarn("Failed to chown stdin");
 
 		if (slavefd_stdout < 0)
 			slavefd_stdout = dev_null_w;
 		if (dup2(slavefd_stdout, STDOUT_FILENO) < 0)
 			pexit("Failed to dup over stdout");
+		if (fchmod(STDOUT_FILENO, 0777) < 0)
+			nwarn("Failed to chown stdout");
 
 		if (slavefd_stderr < 0)
 			slavefd_stderr = slavefd_stdout;
 		if (dup2(slavefd_stderr, STDERR_FILENO) < 0)
 			pexit("Failed to dup over stderr");
+		if (fchmod(STDERR_FILENO, 0777) < 0)
+			nwarn("Failed to chown stderr");
 
 		/* If LISTEN_PID env is set, we need to set the LISTEN_PID
 		   it to the new child process */


### PR DESCRIPTION
make sure every user inside of the container can use the standard
files.  Without the chmod, only root in the container would be able to
print to stdout.

It went unnoticed with runc, as runc itself corrects these permissions
but it should not be the OCI runtime responsibility since conmon is
creating these files.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1786449

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>