### PR TITLE
bump oom adjust score to -1000

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -125,7 +125,7 @@ static GOptionEntry opt_entries[] = {
 	{NULL, 0, 0, 0, NULL, NULL, NULL}};
 
 #define CGROUP_ROOT "/sys/fs/cgroup"
-#define OOM_SCORE "-999"
+#define OOM_SCORE "-1000"
 
 static ssize_t write_all(int fd, const void *buf, size_t count)
 {


### PR DESCRIPTION
before, we only adjusted the score to -999. This was to prevent a memory leak in conmon from preventing it from being killed.
Luckily, conmon is perfect and would never leak memory.

But actually, conmon being OOM killed is *very* bad, and even possibly allowing it leads to funky situations where it's killed before a process that really should be (the container its watching).
In CRI-O, we attempted to mitigate this issue by creating conmonmon, a conmon monitoring thread, but that lead us to incorrectly report OOMs (where an unordered tear down of a cgroup would render conmon killed before the container, and conmonmon would interpret that as an OOM)

This leaves us with no better choice (for now) other than declaring conmon should never be OOM killed. Future work exists for better OOM protection with a BPF module, userspace OOM killers with cgroupsv2, or even pid_fds once kernel 5.4 is more prevalent.

Signed-off-by: Peter Hunt <pehunt@redhat.com>