### PR TITLE
Ignore timeout if container process is already dead.

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -1753,7 +1753,11 @@ int main(int argc, char *argv[])
 	int exit_status = -1;
 	const char *exit_message = NULL;
 
-	if (timed_out) {
+	/*
+	 * If timed_out is TRUE but container_pid is -1, the process must have died before
+	 * the timer elapsed. Ignore the timeout and treat it like a normal container exit.
+	 */
+	if (timed_out && container_pid > 0) {
 		pid_t process_group = getpgid(container_pid);
 
 		if (process_group > 0)


### PR DESCRIPTION
As discussed in #123, there's a race condition where it's possible to get to this point with `timed_out` true and the process already dead (and `container_pid` already cleared). That has rather negative consequences (`kill(-1, SIGKILL)` as root).

Since the container exited on its own, it seems like we should just ignore the timeout and treat it like a normal container exit.

Fixes #123

Signed-off-by: Andrew Drake <andrew@frontapp.com>