### PR TITLE
conmon: drop usage of splice(2)

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((c-mode . ((fill-column . 109)
+            (c-basic-offset . 8)
+            (indent-tabs-mode t))))


### PR DESCRIPTION
splice(2) doesn't seem to handle correctly sockets having a type of SOCK_SEQPACKET.

When using a SOCK_SEQPACKET, each read is limited to the current packet.  The data that doesn't fit in a single read(2) call will be discarded.  This can be a problem when the fd_out doesn't accept all the data, so on a short write we lose the data that could not be written by the splice(2) call.

Replace splice(2) with splitting the read/write loop.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>