### PR TITLE
style: stop declaring variables at top of block

### DIFF
--- a/src/cgroup.c
+++ b/src/cgroup.c
@@ -49,8 +49,7 @@ void setup_oom_handling(int pid)
 static char *process_cgroup_subsystem_path(int pid, bool cgroup2, const char *subsystem)
 {
 	_cleanup_free_ char *cgroups_file_path = g_strdup_printf("/proc/%d/cgroup", pid);
-	_cleanup_fclose_ FILE *fp = NULL;
-	fp = fopen(cgroups_file_path, "re");
+	_cleanup_fclose_ FILE *fp = fopen(cgroups_file_path, "re");
 	if (fp == NULL) {
 		nwarnf("Failed to open cgroups file: %s", cgroups_file_path);
 		return NULL;
@@ -60,8 +59,6 @@ static char *process_cgroup_subsystem_path(int pid, bool cgroup2, const char *su
 	ssize_t read;
 	size_t len = 0;
 	char *ptr, *path;
-	char *subsystem_path = NULL;
-	int i;
 	while ((read = getline(&line, &len, fp)) != -1) {
 		_cleanup_strv_ char **subsystems = NULL;
 		ptr = strchr(line, ':');
@@ -78,12 +75,12 @@ static char *process_cgroup_subsystem_path(int pid, bool cgroup2, const char *su
 		*path = 0;
 		path++;
 		if (cgroup2) {
-			subsystem_path = g_strdup_printf("%s%s", CGROUP_ROOT, path);
+			char *subsystem_path = g_strdup_printf("%s%s", CGROUP_ROOT, path);
 			subsystem_path[strlen(subsystem_path) - 1] = '\0';
 			return subsystem_path;
 		}
 		subsystems = g_strsplit(ptr, ",", -1);
-		for (i = 0; subsystems[i] != NULL; i++) {
+		for (int i = 0; subsystems[i] != NULL; i++) {
 			if (strcmp(subsystems[i], subsystem) == 0) {
 				char *subpath = strchr(subsystems[i], '=');
 				if (subpath == NULL) {
@@ -92,7 +89,7 @@ static char *process_cgroup_subsystem_path(int pid, bool cgroup2, const char *su
 					*subpath = 0;
 				}
 
-				subsystem_path = g_strdup_printf("%s/%s%s", CGROUP_ROOT, subpath, path);
+				char *subsystem_path = g_strdup_printf("%s/%s%s", CGROUP_ROOT, subpath, path);
 				subsystem_path[strlen(subsystem_path) - 1] = '\0';
 				return subsystem_path;
 			}
@@ -105,9 +102,6 @@ static char *process_cgroup_subsystem_path(int pid, bool cgroup2, const char *su
 
 static void setup_oom_handling_cgroup_v2(int pid)
 {
-	_cleanup_close_ int ifd = -1;
-	int wd;
-
 	cgroup2_path = process_cgroup_subsystem_path(pid, true, "");
 	if (!cgroup2_path) {
 		nwarn("Failed to get cgroup path. Container may have exited");
@@ -116,12 +110,13 @@ static void setup_oom_handling_cgroup_v2(int pid)
 
 	_cleanup_free_ char *memory_events_file_path = g_build_filename(cgroup2_path, "memory.events", NULL);
 
+	_cleanup_close_ int ifd = -1;
 	if ((ifd = inotify_init()) < 0) {
 		nwarnf("Failed to create inotify fd");
 		return;
 	}
 
-	if ((wd = inotify_add_watch(ifd, memory_events_file_path, IN_MODIFY)) < 0) {
+	if (inotify_add_watch(ifd, memory_events_file_path, IN_MODIFY) < 0) {
 		nwarnf("Failed to add inotify watch for %s", memory_events_file_path);
 		return;
 	}
@@ -136,11 +131,7 @@ static void setup_oom_handling_cgroup_v2(int pid)
 static void setup_oom_handling_cgroup_v1(int pid)
 {
 	/* Setup OOM notification for container process */
-	_cleanup_free_ char *memory_cgroup_path = NULL;
-	_cleanup_close_ int cfd = -1;
-	int ofd = -1; /* Not closed */
-
-	memory_cgroup_path = process_cgroup_subsystem_path(pid, false, "memory");
+	_cleanup_free_ char *memory_cgroup_path = process_cgroup_subsystem_path(pid, false, "memory");
 	if (!memory_cgroup_path) {
 		nwarn("Failed to get memory cgroup path. Container may have exited");
 		return;
@@ -148,14 +139,16 @@ static void setup_oom_handling_cgroup_v1(int pid)
 
 	/* this will be cleaned up in oom_cb_cgroup_v1 */
 	char *memory_cgroup_file_path = g_build_filename(memory_cgroup_path, "cgroup.event_control", NULL);
-
-	if ((cfd = open(memory_cgroup_file_path, O_WRONLY | O_CLOEXEC)) == -1) {
+	_cleanup_close_ int cfd = open(memory_cgroup_file_path, O_WRONLY | O_CLOEXEC);
+	if (cfd == -1) {
 		nwarnf("Failed to open %s", memory_cgroup_file_path);
 		return;
 	}
 
 	_cleanup_free_ char *memory_cgroup_file_oom_path = g_build_filename(memory_cgroup_path, "memory.oom_control", NULL);
-	if ((ofd = open(memory_cgroup_file_oom_path, O_RDONLY | O_CLOEXEC)) == -1)
+
+	int ofd = open(memory_cgroup_file_oom_path, O_RDONLY | O_CLOEXEC); /* Not closed */
+	if (ofd == -1)
 		pexitf("Failed to open %s", memory_cgroup_file_oom_path);
 
 	if ((oom_event_fd = eventfd(0, EFD_CLOEXEC)) == -1)
@@ -170,15 +163,15 @@ static void setup_oom_handling_cgroup_v1(int pid)
 
 static gboolean oom_cb_cgroup_v2(int fd, GIOCondition condition, G_GNUC_UNUSED gpointer user_data)
 {
-	size_t events_size = sizeof(struct inotify_event) + NAME_MAX + 1;
+	const size_t events_size = sizeof(struct inotify_event) + NAME_MAX + 1;
 	char events[events_size];
-	gboolean ret = G_SOURCE_REMOVE;
 
 	/* Drop the inotify events.  */
 	if (read(fd, &events, events_size) < 0) {
 		pwarn("failed to read events");
 	}
 
+	gboolean ret = G_SOURCE_REMOVE;
 	if ((condition & G_IO_IN) != 0) {
 		ret = check_cgroup2_oom();
 	}
@@ -197,10 +190,6 @@ static gboolean oom_cb_cgroup_v2(int fd, GIOCondition condition, G_GNUC_UNUSED g
 static gboolean oom_cb_cgroup_v1(int fd, GIOCondition condition, gpointer user_data)
 {
 	char *cgroup_event_control_path = (char *)user_data;
-	uint64_t event_count;
-	ssize_t num_read = 0;
-	gboolean cgroup_removed = FALSE;
-
 	if ((condition & G_IO_IN) == 0) {
 		/* End of input */
 		close(fd);
@@ -213,6 +202,7 @@ static gboolean oom_cb_cgroup_v1(int fd, GIOCondition condition, gpointer user_d
 	 * if the cgroup.memory_control file does not exist,
 	 * we know one of the events on this fd was a cgroup removal
 	 */
+	gboolean cgroup_removed = FALSE;
 	if (access(cgroup_event_control_path, F_OK) < 0) {
 		ndebugf("Memory cgroup removal event received");
 		cgroup_removed = TRUE;
@@ -223,7 +213,8 @@ static gboolean oom_cb_cgroup_v1(int fd, GIOCondition condition, gpointer user_d
 	 * cgroup was removed (1 event)
 	 * oom kill happened and cgroup was removed (2 events)
 	 */
-	num_read = read(fd, &event_count, sizeof(uint64_t));
+	uint64_t event_count;
+	ssize_t num_read = read(fd, &event_count, sizeof(uint64_t));
 	if (num_read < 0) {
 		nwarn("Failed to read oom event from eventfd");
 		return G_SOURCE_CONTINUE;
@@ -262,23 +253,22 @@ static gboolean oom_cb_cgroup_v1(int fd, GIOCondition condition, gpointer user_d
 
 gboolean check_cgroup2_oom()
 {
-	_cleanup_free_ char *memory_events_file_path = NULL;
-	_cleanup_free_ char *line = NULL;
-	_cleanup_fclose_ FILE *fp = NULL;
 	static long int last_counter = 0;
-	size_t len = 0;
-	ssize_t read;
 
 	if (!is_cgroup_v2)
 		return G_SOURCE_REMOVE;
 
-	memory_events_file_path = g_build_filename(cgroup2_path, "memory.events", NULL);
+	_cleanup_free_ char *memory_events_file_path = g_build_filename(cgroup2_path, "memory.events", NULL);
 
-	fp = fopen(memory_events_file_path, "re");
+	_cleanup_fclose_ FILE *fp = fopen(memory_events_file_path, "re");
 	if (fp == NULL) {
 		nwarnf("Failed to open cgroups file: %s", memory_events_file_path);
 		return G_SOURCE_CONTINUE;
 	}
+
+	_cleanup_free_ char *line = NULL;
+	size_t len = 0;
+	ssize_t read;
 	while ((read = getline(&line, &len, fp)) != -1) {
 		long int counter;
 
@@ -306,17 +296,15 @@ gboolean check_cgroup2_oom()
  */
 static int write_oom_files()
 {
-	_cleanup_close_ int oom_fd = -1;
 	ninfo("OOM received");
 	if (opt_persist_path) {
-		_cleanup_close_ int ctr_oom_fd = -1;
 		_cleanup_free_ char *ctr_oom_file_path = g_build_filename(opt_persist_path, "oom", NULL);
-		ctr_oom_fd = open(ctr_oom_file_path, O_CREAT, 0666);
+		_cleanup_close_ int ctr_oom_fd = open(ctr_oom_file_path, O_CREAT, 0666);
 		if (ctr_oom_fd < 0) {
 			nwarn("Failed to write oom file");
 		}
 	}
-	oom_fd = open("oom", O_CREAT, 0666);
+	_cleanup_close_ int oom_fd = open("oom", O_CREAT, 0666);
 	if (oom_fd < 0) {
 		nwarn("Failed to write oom file");
 	}

--- a/src/cli.c
+++ b/src/cli.c
@@ -92,18 +92,17 @@ GOptionEntry opt_entries[] = {
 
 int initialize_cli(int argc, char *argv[])
 {
-	GError *error = NULL;
-
-	GOptionContext *context;
-	context = g_option_context_new("- conmon utility");
+	GOptionContext *context = g_option_context_new("- conmon utility");
 	g_option_context_add_main_entries(context, opt_entries, "conmon");
+
+	GError *error = NULL;
 	if (!g_option_context_parse(context, &argc, &argv, &error)) {
 		g_print("conmon: option parsing failed: %s\n", error->message);
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if (opt_version) {
 		g_print("conmon version " VERSION "\ncommit: " GIT_COMMIT "\n");
-		exit(0);
+		exit(EXIT_SUCCESS);
 	}
 
 	if (opt_cid == NULL) {
@@ -115,8 +114,6 @@ int initialize_cli(int argc, char *argv[])
 
 void process_cli()
 {
-	char cwd[PATH_MAX];
-
 	/* Command line parameters */
 	set_conmon_logs(opt_log_level, opt_cid, opt_syslog, opt_log_tag);
 
@@ -142,6 +139,7 @@ void process_cli()
 		pexitf("Runtime path %s is not valid", opt_runtime_path);
 
 	// a user must opt into attaching on an exec
+	char cwd[PATH_MAX];
 	if (opt_bundle_path == NULL && !opt_exec) {
 		if (getcwd(cwd, sizeof(cwd)) == NULL) {
 			nexit("Failed to get working directory");
@@ -153,10 +151,9 @@ void process_cli()
 		nexit("Exec process spec path not provided. Use --exec-process-spec");
 	}
 
-	if (opt_container_pid_file == NULL) {
-		// TODO FIXME I removed default_pid_file here. shouldn't opt_container_pid_file be cleaned up?
+	// TODO FIXME I removed default_pid_file here. shouldn't opt_container_pid_file be cleaned up?
+	if (opt_container_pid_file == NULL)
 		opt_container_pid_file = g_strdup_printf("%s/pidfile-%s", cwd, opt_cid);
-	}
 
 	configure_log_drivers(opt_log_path, opt_log_size_max, opt_cid, opt_name, opt_log_tag);
 }

--- a/src/conn_sock.c
+++ b/src/conn_sock.c
@@ -60,8 +60,6 @@ char *setup_console_socket(void)
 
 char *setup_attach_socket(void)
 {
-	_cleanup_free_ char *attach_sock_path = NULL;
-	char *attach_symlink_dir_path;
 	struct sockaddr_un attach_addr = {0};
 	attach_addr.sun_family = AF_UNIX;
 
@@ -69,13 +67,13 @@ char *setup_attach_socket(void)
 	 * Create a symlink so we don't exceed unix domain socket
 	 * path length limit.
 	 */
-	attach_symlink_dir_path = g_build_filename(opt_socket_path, opt_cuuid, NULL);
+	char *attach_symlink_dir_path = g_build_filename(opt_socket_path, opt_cuuid, NULL);
 	if (unlink(attach_symlink_dir_path) == -1 && errno != ENOENT)
 		pexit("Failed to remove existing symlink for attach socket directory");
 
 	/*
-	 * This is to address a corner case where the symlink path length can end up to be
-	 * the same as the socket.  When it happens, the symlink prevents the socket to be
+	 * This is to address a corner case where the symlink path length can end up being
+	 * the same as the socket.  When it happens, the symlink prevents the socket from being
 	 * be created.  This could still be a problem with other containers, but it is safe
 	 * to assume the CUUIDs don't change length in the same directory.  As a workaround,
 	 *  in such case, make the symlink one char shorter.
@@ -86,7 +84,7 @@ char *setup_attach_socket(void)
 	if (symlink(opt_bundle_path, attach_symlink_dir_path) == -1)
 		pexit("Failed to create symlink for attach socket");
 
-	attach_sock_path = g_build_filename(opt_socket_path, opt_cuuid, "attach", NULL);
+	_cleanup_free_ char *attach_sock_path = g_build_filename(opt_socket_path, opt_cuuid, "attach", NULL);
 	ninfof("attach sock path: %s", attach_sock_path);
 
 	strncpy(attach_addr.sun_path, attach_sock_path, sizeof(attach_addr.sun_path) - 1);

--- a/src/runtime_args.c
+++ b/src/runtime_args.c
@@ -7,8 +7,7 @@ static void end_argv(GPtrArray *argv_array);
 
 GPtrArray *configure_runtime_args(const char *const csname)
 {
-	GPtrArray *runtime_argv = NULL;
-	runtime_argv = g_ptr_array_new();
+	GPtrArray *runtime_argv = g_ptr_array_new();
 	add_argv(runtime_argv, opt_runtime_path, NULL);
 
 	/* Generate the cmdline. */

--- a/src/utils.c
+++ b/src/utils.c
@@ -5,6 +5,7 @@
 log_level_t log_level = WARN_LEVEL;
 char *log_cid = NULL;
 gboolean use_syslog = FALSE;
+
 /* Set the log level for this call. log level defaults to warning.
    parse the string value of level_name to the appropriate log_level_t enum value
 */

--- a/src/utils.h
+++ b/src/utils.h
@@ -185,6 +185,12 @@ static inline void gstring_free_cleanup(GString **string)
 		g_string_free(*string, TRUE);
 }
 
+static inline void gerror_free_cleanup(GError **err)
+{
+	if (*err)
+		g_error_free(*err);
+}
+
 static inline void strv_cleanup(char ***strv)
 {
 	if (strv)
@@ -195,6 +201,7 @@ static inline void strv_cleanup(char ***strv)
 #define _cleanup_close_ _cleanup_(closep)
 #define _cleanup_fclose_ _cleanup_(fclosep)
 #define _cleanup_gstring_ _cleanup_(gstring_free_cleanup)
+#define _cleanup_gerror_ _cleanup_(gerror_free_cleanup)
 #define _cleanup_strv_ _cleanup_(strv_cleanup)
 
 


### PR DESCRIPTION
we already mandate C99, and I find code is easier to read when a variable is declared when its needed

Signed-off-by: Peter Hunt <pehunt@redhat.com>