### PR TITLE
WIP: add --output-file

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -45,6 +45,7 @@ gchar **opt_exit_args = NULL;
 gboolean opt_replace_listen_pid = FALSE;
 char *opt_log_level = NULL;
 char *opt_log_tag = NULL;
+char *opt_output_file = NULL;
 GOptionEntry opt_entries[] = {
 	{"terminal", 't', 0, G_OPTION_ARG_NONE, &opt_terminal, "Terminal", NULL},
 	{"stdin", 'i', 0, G_OPTION_ARG_NONE, &opt_stdin, "Stdin", NULL},
@@ -87,6 +88,7 @@ GOptionEntry opt_entries[] = {
 	{"syslog", 0, 0, G_OPTION_ARG_NONE, &opt_syslog, "Log to syslog (use with cgroupfs cgroup manager)", NULL},
 	{"log-level", 0, 0, G_OPTION_ARG_STRING, &opt_log_level, "Print debug logs based on log level", NULL},
 	{"log-tag", 0, 0, G_OPTION_ARG_STRING, &opt_log_tag, "Additional tag to use for logging", NULL},
+	{"output-file", 0, 0, G_OPTION_ARG_STRING, &opt_output_file, "File to write conmon logs to", NULL},
 	{NULL, 0, 0, 0, NULL, NULL, NULL}};
 
 
@@ -112,10 +114,10 @@ int initialize_cli(int argc, char *argv[])
 	return -1;
 }
 
-void process_cli()
+void process_cli(FILE **conmon_output_file)
 {
 	/* Command line parameters */
-	set_conmon_logs(opt_log_level, opt_cid, opt_syslog, opt_log_tag);
+	set_conmon_logs(opt_log_level, opt_cid, opt_syslog, opt_log_tag, opt_output_file, conmon_output_file);
 
 
 	main_loop = g_main_loop_new(NULL, FALSE);

--- a/src/cli.h
+++ b/src/cli.h
@@ -1,7 +1,8 @@
 #if !defined(CLI_H)
 #define CLI_H
 
-#include <glib.h> /* gboolean and GOptionEntry */
+#include <glib.h>  /* gboolean and GOptionEntry */
+#include <stdio.h> /* FILE */
 
 extern gboolean opt_version;
 extern gboolean opt_terminal;
@@ -41,6 +42,6 @@ extern char *opt_log_tag;
 extern GOptionEntry opt_entries[];
 
 int initialize_cli(int argc, char *argv[]);
-void process_cli();
+void process_cli(FILE **conmon_output_file);
 
 #endif // CLI_H

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -36,7 +36,8 @@ int main(int argc, char *argv[])
 		exit(initialize_ec);
 	}
 
-	process_cli();
+	_cleanup_fclose_ FILE *conmon_output_file = NULL;
+	process_cli(&conmon_output_file);
 
 	attempt_oom_adjust();
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -5,16 +5,25 @@
 log_level_t log_level = WARN_LEVEL;
 char *log_cid = NULL;
 gboolean use_syslog = FALSE;
+FILE *output_file = NULL;
 
 /* Set the log level for this call. log level defaults to warning.
    parse the string value of level_name to the appropriate log_level_t enum value
 */
-void set_conmon_logs(char *level_name, char *cid_, gboolean syslog_, char *tag)
+void set_conmon_logs(char *level_name, char *cid_, gboolean syslog_, char *tag, char *opt_output_file_, FILE **conmon_output_file_)
 {
 	if (tag == NULL)
 		log_cid = cid_;
 	else
 		log_cid = g_strdup_printf("%s: %s", cid_, tag);
+
+	output_file = stderr;
+	if (opt_output_file_ != NULL) {
+		*conmon_output_file_ = fopen(opt_output_file_, "a");
+		output_file = *conmon_output_file_;
+	}
+
+
 	use_syslog = syslog_;
 	// log_level is initialized as Warning, no need to set anything
 	if (level_name == NULL)

--- a/src/utils.h
+++ b/src/utils.h
@@ -33,10 +33,11 @@ typedef enum {
 extern log_level_t log_level;
 extern char *log_cid;
 extern gboolean use_syslog;
+extern FILE *output_file;
 
 #define _pexit(s) \
 	do { \
-		fprintf(stderr, "[conmon:e]: %s %s\n", s, strerror(errno)); \
+		fprintf(output_file, "[conmon:e]: %s %s\n", s, strerror(errno)); \
 		if (use_syslog) \
 			syslog(LOG_ERR, "conmon %.20s <error>: %s %s\n", log_cid, s, strerror(errno)); \
 		_exit(EXIT_FAILURE); \
@@ -44,7 +45,7 @@ extern gboolean use_syslog;
 
 #define pexit(s) \
 	do { \
-		fprintf(stderr, "[conmon:e]: %s %s\n", s, strerror(errno)); \
+		fprintf(output_file, "[conmon:e]: %s %s\n", s, strerror(errno)); \
 		if (use_syslog) \
 			syslog(LOG_ERR, "conmon %.20s <error>: %s %s\n", log_cid, s, strerror(errno)); \
 		exit(EXIT_FAILURE); \
@@ -52,7 +53,7 @@ extern gboolean use_syslog;
 
 #define pexitf(fmt, ...) \
 	do { \
-		fprintf(stderr, "[conmon:e]: " fmt " %s\n", ##__VA_ARGS__, strerror(errno)); \
+		fprintf(output_file, "[conmon:e]: " fmt " %s\n", ##__VA_ARGS__, strerror(errno)); \
 		if (use_syslog) \
 			syslog(LOG_ERR, "conmon %.20s <error>: " fmt ": %s\n", log_cid, ##__VA_ARGS__, strerror(errno)); \
 		exit(EXIT_FAILURE); \
@@ -60,14 +61,14 @@ extern gboolean use_syslog;
 
 #define pwarn(s) \
 	do { \
-		fprintf(stderr, "[conmon:w]: %s %s\n", s, strerror(errno)); \
+		fprintf(output_file, "[conmon:w]: %s %s\n", s, strerror(errno)); \
 		if (use_syslog) \
 			syslog(LOG_INFO, "conmon %.20s <pwarn>: %s %s\n", log_cid, s, strerror(errno)); \
 	} while (0)
 
 #define nexit(s) \
 	do { \
-		fprintf(stderr, "[conmon:e] %s\n", s); \
+		fprintf(output_file, "[conmon:e] %s\n", s); \
 		if (use_syslog) \
 			syslog(LOG_ERR, "conmon %.20s <error>: %s\n", log_cid, s); \
 		exit(EXIT_FAILURE); \
@@ -75,7 +76,7 @@ extern gboolean use_syslog;
 
 #define nexitf(fmt, ...) \
 	do { \
-		fprintf(stderr, "[conmon:e]: " fmt "\n", ##__VA_ARGS__); \
+		fprintf(output_file, "[conmon:e]: " fmt "\n", ##__VA_ARGS__); \
 		if (use_syslog) \
 			syslog(LOG_ERR, "conmon %.20s <error>: " fmt " \n", log_cid, ##__VA_ARGS__); \
 		exit(EXIT_FAILURE); \
@@ -84,7 +85,7 @@ extern gboolean use_syslog;
 #define nwarn(s) \
 	if (log_level >= WARN_LEVEL) { \
 		do { \
-			fprintf(stderr, "[conmon:w]: %s\n", s); \
+			fprintf(output_file, "[conmon:w]: %s\n", s); \
 			if (use_syslog) \
 				syslog(LOG_INFO, "conmon %.20s <nwarn>: %s\n", log_cid, s); \
 		} while (0); \
@@ -93,7 +94,7 @@ extern gboolean use_syslog;
 #define nwarnf(fmt, ...) \
 	if (log_level >= WARN_LEVEL) { \
 		do { \
-			fprintf(stderr, "[conmon:w]: " fmt "\n", ##__VA_ARGS__); \
+			fprintf(output_file, "[conmon:w]: " fmt "\n", ##__VA_ARGS__); \
 			if (use_syslog) \
 				syslog(LOG_INFO, "conmon %.20s <nwarn>: " fmt " \n", log_cid, ##__VA_ARGS__); \
 		} while (0); \
@@ -102,7 +103,7 @@ extern gboolean use_syslog;
 #define ninfo(s) \
 	if (log_level >= INFO_LEVEL) { \
 		do { \
-			fprintf(stderr, "[conmon:i]: %s\n", s); \
+			fprintf(output_file, "[conmon:i]: %s\n", s); \
 			if (use_syslog) \
 				syslog(LOG_INFO, "conmon %.20s <ninfo>: %s\n", log_cid, s); \
 		} while (0); \
@@ -111,7 +112,7 @@ extern gboolean use_syslog;
 #define ninfof(fmt, ...) \
 	if (log_level >= INFO_LEVEL) { \
 		do { \
-			fprintf(stderr, "[conmon:i]: " fmt "\n", ##__VA_ARGS__); \
+			fprintf(output_file, "[conmon:i]: " fmt "\n", ##__VA_ARGS__); \
 			if (use_syslog) \
 				syslog(LOG_INFO, "conmon %.20s <ninfo>: " fmt " \n", log_cid, ##__VA_ARGS__); \
 		} while (0); \
@@ -120,7 +121,7 @@ extern gboolean use_syslog;
 #define ndebug(s) \
 	if (log_level >= DEBUG_LEVEL) { \
 		do { \
-			fprintf(stderr, "[conmon:d]: %s\n", s); \
+			fprintf(output_file, "[conmon:d]: %s\n", s); \
 			if (use_syslog) \
 				syslog(LOG_INFO, "conmon %.20s <ndebug>: %s\n", log_cid, s); \
 		} while (0); \
@@ -129,7 +130,7 @@ extern gboolean use_syslog;
 #define ndebugf(fmt, ...) \
 	if (log_level >= DEBUG_LEVEL) { \
 		do { \
-			fprintf(stderr, "[conmon:d]: " fmt "\n", ##__VA_ARGS__); \
+			fprintf(output_file, "[conmon:d]: " fmt "\n", ##__VA_ARGS__); \
 			if (use_syslog) \
 				syslog(LOG_INFO, "conmon %.20s <ndebug>: " fmt " \n", log_cid, ##__VA_ARGS__); \
 		} while (0); \
@@ -138,7 +139,7 @@ extern gboolean use_syslog;
 #define ntrace(s) \
 	if (log_level >= TRACE_LEVEL) { \
 		do { \
-			fprintf(stderr, "[conmon:d]: %s\n", s); \
+			fprintf(output_file, "[conmon:d]: %s\n", s); \
 			if (use_syslog) \
 				syslog(LOG_INFO, "conmon %.20s <ntrace>: %s\n", log_cid, s); \
 		} while (0); \
@@ -147,7 +148,7 @@ extern gboolean use_syslog;
 #define ntracef(fmt, ...) \
 	if (log_level >= TRACE_LEVEL) { \
 		do { \
-			fprintf(stderr, "[conmon:d]: " fmt "\n", ##__VA_ARGS__); \
+			fprintf(output_file, "[conmon:d]: " fmt "\n", ##__VA_ARGS__); \
 			if (use_syslog) \
 				syslog(LOG_INFO, "conmon %.20s <ntrace>: " fmt " \n", log_cid, ##__VA_ARGS__); \
 		} while (0); \
@@ -156,7 +157,7 @@ extern gboolean use_syslog;
 /* Set the log level for this call. log level defaults to warning.
    parse the string value of level_name to the appropriate log_level_t enum value
 */
-void set_conmon_logs(char *level_name, char *cid_, gboolean syslog_, char *tag);
+void set_conmon_logs(char *level_name, char *cid_, gboolean syslog_, char *tag, char *opt_output_file_, FILE **conmon_output_file_);
 
 #define _cleanup_(x) __attribute__((cleanup(x)))
 


### PR DESCRIPTION
a major drawback of conmon's double forking model is the parent loses stderr after the fork. This makes debugging challenging.

Add --output-file, allowing the caller to specify a file to write conmon's logs to. Eventually, all container engines should use this option instead of the default `stderr`

Signed-off-by: Peter Hunt <pehunt@redhat.com>