### PR TITLE
conmon: store status while waiting for pid

### DIFF
--- a/src/ctr_exit.h
+++ b/src/ctr_exit.h
@@ -8,10 +8,15 @@
 extern volatile pid_t container_pid;
 extern volatile pid_t create_pid;
 
+struct pid_check_data {
+	GHashTable *pid_to_handler;
+	GHashTable *exit_status_cache;
+};
+
 void on_sigchld(G_GNUC_UNUSED int signal);
 void on_sig_exit(int signal);
 void container_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointer user_data);
-void check_child_processes(GHashTable *pid_to_handler);
+gboolean check_child_processes_cb(gpointer user_data);
 gboolean on_sigusr1_cb(gpointer user_data);
 gboolean timeout_cb(G_GNUC_UNUSED gpointer user_data);
 int get_exit_status(int status);


### PR DESCRIPTION
store each termination status reported to us while waiting for the container PID file to be created.

Once we know the container PID we check in the cache whether we already know the status.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
