### PR TITLE
some small cleanups

### DIFF
--- a/src/cgroup.c
+++ b/src/cgroup.c
@@ -168,8 +168,10 @@ static gboolean oom_cb_cgroup_v2(int fd, GIOCondition condition, G_GNUC_UNUSED g
 	char events[events_size];
 
 	/* Drop the inotify events.  */
-	if (read(fd, &events, events_size) < 0) {
-		pwarn("failed to read events");
+	ssize_t num_read = read(fd, &events, events_size);
+	if (num_read < 0) {
+		nwarn("Failed to read oom event from eventfd in v2");
+		return G_SOURCE_CONTINUE;
 	}
 
 	gboolean ret = G_SOURCE_REMOVE;

--- a/src/cli.c
+++ b/src/cli.c
@@ -113,6 +113,10 @@ int initialize_cli(int argc, char *argv[])
 		g_print("conmon: option parsing failed: %s\n", error->message);
 		exit(EXIT_FAILURE);
 	}
+
+	g_option_context_free(context);
+	context = NULL;
+
 	if (opt_version) {
 		g_print("conmon version " VERSION "\ncommit: " GIT_COMMIT "\n");
 		exit(EXIT_SUCCESS);

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
 		pexit("Failed to unblock signals");
 
 	/* Map pid to its handler.  */
-	GHashTable *pid_to_handler = g_hash_table_new(g_int_hash, g_int_equal);
+	_cleanup_hashtable_ GHashTable *pid_to_handler = g_hash_table_new(g_int_hash, g_int_equal);
 	g_hash_table_insert(pid_to_handler, (pid_t *)&create_pid, runtime_exit_cb);
 
 	/*

--- a/src/ctrl.c
+++ b/src/ctrl.c
@@ -34,6 +34,7 @@ gboolean terminal_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC
 	const char *csname = user_data;
 	if (unlink(csname) < 0)
 		nwarnf("failed to unlink %s", csname);
+
 	close(fd);
 
 	/* We exit if this fails. */

--- a/src/utils.h
+++ b/src/utils.h
@@ -206,12 +206,19 @@ static inline void strv_cleanup(char ***strv)
 		g_strfreev(*strv);
 }
 
+static inline void hashtable_free_cleanup(GHashTable **tbl)
+{
+	if (tbl)
+		g_hash_table_destroy(*tbl);
+}
+
 #define _cleanup_free_ _cleanup_(freep)
 #define _cleanup_close_ _cleanup_(closep)
 #define _cleanup_fclose_ _cleanup_(fclosep)
 #define _cleanup_gstring_ _cleanup_(gstring_free_cleanup)
 #define _cleanup_gerror_ _cleanup_(gerror_free_cleanup)
 #define _cleanup_strv_ _cleanup_(strv_cleanup)
+#define _cleanup_hashtable_ _cleanup_(hashtable_free_cleanup)
 
 
 #define WRITEV_BUFFER_N_IOV 128


### PR DESCRIPTION
clear memory when allocated for GContext and GHashTable
check return value when we unlink (to fix one aspect that popped up in coverity scan)

Signed-off-by: Peter Hunt <pehunt@redhat.com>