### PR TITLE
Usability fixes

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -138,19 +138,23 @@ void process_cli()
 	if (access(opt_runtime_path, X_OK) < 0)
 		pexitf("Runtime path %s is not valid", opt_runtime_path);
 
-	// a user must opt into attaching on an exec
-	char cwd[PATH_MAX];
-	if (opt_bundle_path == NULL && !opt_exec) {
-		if (getcwd(cwd, sizeof(cwd)) == NULL) {
-			nexit("Failed to get working directory");
-		}
-		opt_bundle_path = cwd;
-	}
-
 	if (opt_exec && opt_exec_process_spec == NULL) {
 		nexit("Exec process spec path not provided. Use --exec-process-spec");
 	}
 
+	char cwd[PATH_MAX];
+	if (getcwd(cwd, sizeof(cwd)) == NULL) {
+		nexit("Failed to get working directory");
+	}
+
+	// opt_bundle_path in exec means we will set up the attach socket
+	// for the exec session. the legacy version of exec does not need this
+	// and thus we only override an empty opt_bundle_path when we're not exec
+	if (opt_bundle_path == NULL && !opt_exec) {
+		opt_bundle_path = cwd;
+	}
+
+	// we should always override the container pid file if it's empty
 	// TODO FIXME I removed default_pid_file here. shouldn't opt_container_pid_file be cleaned up?
 	if (opt_container_pid_file == NULL)
 		opt_container_pid_file = g_strdup_printf("%s/pidfile-%s", cwd, opt_cid);

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -328,23 +328,23 @@ int main(int argc, char *argv[])
 	}
 
 	if (!WIFEXITED(runtime_status) || WEXITSTATUS(runtime_status) != 0) {
-		if (sync_pipe_fd > 0) {
-			/*
-			 * Read from container stderr for any error and send it to parent
-			 * We send -1 as pid to signal to parent that create container has failed.
-			 */
-			num_read = read(masterfd_stderr, buf, BUF_SIZE - 1);
-			if (num_read > 0) {
-				buf[num_read] = '\0';
+		/*
+		 * Read from container stderr for any error and send it to parent
+		 * We send -1 as pid to signal to parent that create container has failed.
+		 */
+		num_read = read(masterfd_stderr, buf, BUF_SIZE - 1);
+		if (num_read > 0) {
+			buf[num_read] = '\0';
+			nwarnf("runtime stderr: %s", buf);
+			if (sync_pipe_fd > 0) {
 				int to_report = -1;
 				if (opt_exec && container_status > 0) {
 					to_report = -1 * container_status;
 				}
-
 				write_sync_fd(sync_pipe_fd, to_report, buf);
 			}
 		}
-		nexitf("Failed to create container: exit status %d", get_exit_status(runtime_status));
+		nexitf("Failed tooth create container: exit status %d", get_exit_status(runtime_status));
 	}
 
 	if (opt_terminal && masterfd_stdout == -1)


### PR DESCRIPTION
properly set container-pid-file when it is not specified
print runtime stderr to journal when it fails