### PR TITLE
tty: flush pending data when fd is ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ static:
 	$(MAKE) git-vars bin/conmon PKG_CONFIG='$(PKG_CONFIG) --static' CFLAGS='-static' LDFLAGS='$(LDFLAGS) -s -w -static' LIBS='$(LIBS)'
 
 bin/conmon: $(OBJS) | bin
-	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(CC) $(LDFLAGS) $(CFLAGS) -o $@ $^ $(LIBS)
 
 %.o: %.c $(HEADERS)
 	$(CC) $(CFLAGS) -o $@ -c $<

--- a/src/conn_sock.h
+++ b/src/conn_sock.h
@@ -18,5 +18,6 @@ struct conn_sock_s {
 char *setup_console_socket(void);
 char *setup_attach_socket(void);
 void conn_sock_shutdown(struct conn_sock_s *sock, int how);
+void schedule_master_stdin_write();
 
 #endif // CONN_SOCK_H

--- a/src/ctrl.c
+++ b/src/ctrl.c
@@ -5,6 +5,7 @@
 #include "globals.h"
 #include "config.h"
 #include "ctr_logging.h"
+#include "conn_sock.h"
 #include "cmsg.h"
 #include "cli.h" // opt_bundle_path
 
@@ -58,6 +59,10 @@ exit:
 	 * stdout. stderr is ignored. */
 	masterfd_stdin = console.fd;
 	masterfd_stdout = console.fd;
+
+	/* Now that we have a fd to the tty, make sure we handle any pending data
+	 * that was already buffered. */
+	schedule_master_stdin_write();
 
 	/* now that we've set masterfd_stdout, we can register the ctrl_winsz_cb
 	 * if we didn't set it here, we'd risk attempting to run ioctl on


### PR DESCRIPTION
if there was any data already received, make sure it is flushed to the tty as soon as it is opened.

Closes: https://github.com/containers/libpod/issues/4397

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
