### PR TITLE
Add option to delay execution of exit command

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -42,6 +42,7 @@ char *opt_socket_path = DEFAULT_SOCKET_PATH;
 gboolean opt_no_new_keyring = FALSE;
 char *opt_exit_command = NULL;
 gchar **opt_exit_args = NULL;
+int opt_exit_delay = 0;
 gboolean opt_replace_listen_pid = FALSE;
 char *opt_log_level = NULL;
 char *opt_log_tag = NULL;
@@ -77,6 +78,7 @@ GOptionEntry opt_entries[] = {
 	{"exit-dir", 0, 0, G_OPTION_ARG_STRING, &opt_exit_dir, "Path to the directory where exit files are written", NULL},
 	{"exit-command", 0, 0, G_OPTION_ARG_STRING, &opt_exit_command,
 	 "Path to the program to execute when the container terminates its execution", NULL},
+	{"exit-delay", 0, 0, G_OPTION_ARG_INT, &opt_exit_delay, "Delay before invoking the exit command (in seconds)", NULL},
 	{"exit-command-arg", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_exit_args,
 	 "Additional arg to pass to the exit command.  Can be specified multiple times", NULL},
 	{"log-path", 'l', 0, G_OPTION_ARG_STRING_ARRAY, &opt_log_path, "Log file path", NULL},
@@ -149,6 +151,10 @@ void process_cli()
 
 	if (opt_exec && opt_exec_process_spec == NULL) {
 		nexit("Exec process spec path not provided. Use --exec-process-spec");
+	}
+
+	if (opt_exit_delay < 0) {
+		nexit("Delay before invoking exit command must be greater than or equal to 0");
 	}
 
 	// TODO FIXME I removed default_pid_file here. shouldn't opt_container_pid_file be cleaned up?

--- a/src/cli.h
+++ b/src/cli.h
@@ -35,6 +35,7 @@ extern char *opt_socket_path;
 extern gboolean opt_no_new_keyring;
 extern char *opt_exit_command;
 extern gchar **opt_exit_args;
+extern int opt_exit_delay;
 extern gboolean opt_replace_listen_pid;
 extern char *opt_log_level;
 extern char *opt_log_tag;

--- a/src/ctr_exit.c
+++ b/src/ctr_exit.c
@@ -1,7 +1,7 @@
 #define _GNU_SOURCE
 
 #include "ctr_exit.h"
-#include "cli.h" // opt_exit_command
+#include "cli.h" // opt_exit_command, opt_exit_delay
 #include "utils.h"
 #include "parent_pipe_fd.h"
 #include "globals.h"
@@ -175,6 +175,11 @@ void do_exit_command()
 		for (n_args = 0; opt_exit_args[n_args]; n_args++)
 			args[n_args + 1] = opt_exit_args[n_args];
 	args[n_args + 1] = NULL;
+
+	if (opt_exit_delay) {
+		ndebugf("Sleeping for %d seconds before executing exit command", opt_exit_delay);
+		sleep(opt_exit_delay);
+	}
 
 	execv(opt_exit_command, args);
 


### PR DESCRIPTION
This is inspired by a need to periodically reap exec sessions within Podman. When launched from the HTTP API, exec sessions must persist for some amount of time after they exit (Docker runs a reaper every 5 minutes, marking inactive sessions and then removing sessions that are already marked on a subsequent run).

Rather than doing this in Podman, which does not have a daemon, it seems logical to leverage Conmon. We're already using Conmon's exit command infrastructure to clean up detached exec sessions, so it's not much of a stretch to use it for this. The change itself is quite simple (new argument to set a delay, and then a sleep before the exit command is invoked).