### PR TITLE
Add nix derivation for static builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ dkms.conf
 bin/
 
 vendor/
+
+result

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ containerized: bin
 static:
 	$(MAKE) git-vars bin/conmon PKG_CONFIG='$(PKG_CONFIG) --static' CFLAGS='-static' LDFLAGS='$(LDFLAGS) -s -w -static' LIBS='$(LIBS)'
 
+nixpkgs:
+	@nix run -f channel:nixpkgs-unstable nix-prefetch-git -c nix-prefetch-git \
+		--no-deepClone https://github.com/nixos/nixpkgs > nix/nixpkgs.json
+
 bin/conmon: $(OBJS) | bin
 	$(CC) $(LDFLAGS) $(CFLAGS) -o $@ $^ $(LIBS)
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,48 @@
+{ system ? builtins.currentSystem }:
+let
+  pkgs = (import ./nixpkgs.nix {
+    overlays = [ (final: prev: {
+      pcre = prev.pcre.overrideAttrs (x: {
+        configureFlags = x.configureFlags ++ [ "--enable-static" ];
+      });
+    })];
+    config = {
+      packageOverrides = pkg: {
+        glib = pkg.glib.overrideAttrs(x: {
+          outputs = [ "bin" "out" "dev" ];
+          mesonFlags = [
+            "-Ddefault_library=static"
+            "-Ddevbindir=${placeholder ''dev''}/bin"
+            "-Dgtk_doc=false"
+            "-Dnls=disabled"
+          ];
+        });
+        systemd = pkg.systemd.overrideAttrs(x: {
+          mesonFlags = x.mesonFlags ++ [ "-Dstatic-libsystemd=true" ];
+          postFixup = ''
+            ${x.postFixup}
+            sed -ri "s;$out/(.*);$nukedRef/\1;g" $lib/lib/libsystemd.a
+          '';
+        });
+      };
+    };
+  });
+
+  self = with pkgs; {
+    conmon-static = (conmon.overrideAttrs(x: {
+      name = "conmon-static";
+      src = ./..;
+      doCheck = false;
+      buildInputs = [
+        glib
+        glibc
+        glibc.static
+        pcre
+        systemd
+      ];
+      prePatch = ''
+        export LDFLAGS='-static-libgcc -static'
+      '';
+    }));
+  };
+in self

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nixos/nixpkgs",
+  "rev": "1b5925f2189dc9b4ebf7168252bf89a94b7405ba",
+  "date": "2020-05-27T15:03:28+02:00",
+  "path": "/nix/store/qdsrj7hw9wzzng9l2kfbsyi9ynprrn6p-nixpkgs",
+  "sha256": "0q9plknr294k4bjfqvgvp5vglfby5yn64k6ml0gqwi0dwf0qi6fv",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+  json = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = import (builtins.fetchTarball {
+    name = "nixos-unstable";
+    url = "${json.url}/archive/${json.rev}.tar.gz";
+    inherit (json) sha256;
+  });
+in nixpkgs


### PR DESCRIPTION
Switching from the current static build to a nix based derivation.

Similar PR will go for crun/conmon/libpod/etc, too.

Also see
- ~~https://github.com/containers/crun/pull/372~~
- https://github.com/containers/conmon/pull/161
- https://github.com/containers/libpod/pull/6402

Fixes #156

P.S. conmon-v2.0.17 with nix-based binary could be found from https://github.com/alvistack/conmon/releases/tag/v2.0.17