### PR TITLE
ctrl: warn if we fail to unlink

### DIFF
--- a/src/ctrl.c
+++ b/src/ctrl.c
@@ -32,7 +32,8 @@ gboolean terminal_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC
 
 	/* Not accepting anything else. */
 	const char *csname = user_data;
-	unlink(csname);
+	if (unlink(csname) < 0)
+		nwarnf("failed to unlink %s", csname);
 	close(fd);
 
 	/* We exit if this fails. */


### PR DESCRIPTION
to appease coverity scans

Signed-off-by: Peter Hunt <pehunt@redhat.com>