### PR TITLE
WIP: conn_sock: close stdout side when we don't close stdin

### DIFF
--- a/src/conn_sock.c
+++ b/src/conn_sock.c
@@ -192,7 +192,14 @@ static gboolean terminate_conn_sock(struct conn_sock_s *sock)
 			close(masterfd_stdin);
 			masterfd_stdin = -1;
 		} else {
-			ninfo("Not closing input");
+			/*
+			 * In the terminal case, stdin and stdout point to the same fd: the sock.
+			 * If we're told by the caller to leave stdin open, then we'll never close either masterfd_stdin or masterfd_stdout
+			 * the former is desired, but the latter means the caller will sit waiting on a read() on the sock.
+			 * to avoid this, we need to close the stdout side of the sock here
+			 */
+			ninfo("Not closing input, but closing output");
+			conn_sock_shutdown(sock, SHUT_WR);
 		}
 	}
 	return G_SOURCE_REMOVE;


### PR DESCRIPTION
the main consumer of leave-stdin-open, cri-o, needs stdin to stay open, but also wants to consume all data from stdout.
It does not know when the output from stdout has ended unless conmon closes its side of the pipe.

the problem is, if we don't close masterfd_stdin, we also don't close masterfd_stdout, as they point to the same side pipe, which results in cri-o sitting and waiting for input forever.

instead, we need to close the stdout side of the pipe if we don't close masterfd_stdin

Signed-off-by: Peter Hunt <pehunt@redhat.com>