### PR TITLE
[nix] Use `stdenv.mkDerivation` instead of `conmon.overrideAttrs`

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -28,21 +28,18 @@ let
     };
   });
 
-  self = with pkgs; {
-    conmon-static = (conmon.overrideAttrs(x: {
-      name = "conmon-static";
-      src = ./..;
-      doCheck = false;
-      buildInputs = [
-        glib
-        glibc
-        glibc.static
-        pcre
-        systemd
-      ];
-      prePatch = ''
-        export LDFLAGS='-static-libgcc -static'
-      '';
-    }));
+  self = with pkgs; stdenv.mkDerivation rec {
+    name = "conmon";
+    src = ./..;
+    doCheck = false;
+    enableParallelBuilding = true;
+    nativeBuildInputs = [ git pkg-config ];
+    buildInputs = [ glib glibc glibc.static pcre systemd ];
+    prePatch = ''
+      export LDFLAGS='-static-libgcc -static -s -w'
+    '';
+    installPhase = ''
+      install -Dm755 bin/conmon $out/bin/conmon
+    '';
   };
 in self

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "1b5925f2189dc9b4ebf7168252bf89a94b7405ba",
-  "date": "2020-05-27T15:03:28+02:00",
-  "path": "/nix/store/qdsrj7hw9wzzng9l2kfbsyi9ynprrn6p-nixpkgs",
-  "sha256": "0q9plknr294k4bjfqvgvp5vglfby5yn64k6ml0gqwi0dwf0qi6fv",
+  "rev": "0f114432d4a9399e0b225d5be1599c7ebc5e2772",
+  "date": "2020-05-29T19:54:08-05:00",
+  "path": "/nix/store/ds31sjj3ppsk0xclkficx9p3w6qslmdc-nixpkgs",
+  "sha256": "1qd2dlc5dk98y0xdahv9k72ibv5dsy10jg25xqvj38sadxbs3g0j",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
Using `conmon.overrideAttrs` may result as broken due to nixpkgs upstream changes; replace with native `stdenv.mkDerivation` with complete definition could simply avoid this happening.

Changes based on https://github.com/NixOS/nixpkgs/blob/e469b77/pkgs/applications/virtualization/conmon/default.nix; also fix `conmon --version` with correct version and commit, e.g.

```
conmon version 2.0.17
commit: 6be2eb8bb24fc403183ad5186a381ae61151b372

```

Fixes #168

Signed-off-by: Wong Hoi Sing Edison <hswong3i@gmail.com>