### PR TITLE
Update log-path parsing and unit-tests to handle a lot more edge cases.

### DIFF
--- a/runner/conmon/options.go
+++ b/runner/conmon/options.go
@@ -52,6 +52,12 @@ func WithRuntimePath(path string) ConmonOption {
 	}
 }
 
+func WithLogLevel(path string) ConmonOption {
+	return func(ci *ConmonInstance) error {
+		return ci.addArgs("--log-level", path)
+	}
+}
+
 func WithLogDriver(driver, path string) ConmonOption {
 	return func(ci *ConmonInstance) error {
 		fullDriver := path
@@ -59,6 +65,12 @@ func WithLogDriver(driver, path string) ConmonOption {
 			fullDriver = fmt.Sprintf("%s:%s", driver, path)
 		}
 		return ci.addArgs("--log-path", fullDriver)
+	}
+}
+
+func WithLogPath(path string) ConmonOption {
+	return func(ci *ConmonInstance) error {
+		return ci.addArgs("--log-path", path)
 	}
 }
 

--- a/runner/conmon_test/conmon_test.go
+++ b/runner/conmon_test/conmon_test.go
@@ -83,14 +83,19 @@ var _ = Describe("conmon", func() {
 	Describe("ctr logs", func() {
 		var tmpDir string
 		var tmpLogPath string
+		var origCwd string
 		BeforeEach(func() {
 			d, err := ioutil.TempDir(os.TempDir(), "conmon-")
 			Expect(err).To(BeNil())
 			tmpDir = d
 			tmpLogPath = filepath.Join(tmpDir, "log")
+			origCwd, err = os.Getwd()
+			Expect(err).To(BeNil())
 		})
 		AfterEach(func() {
 			Expect(os.RemoveAll(tmpDir)).To(BeNil())
+			err := os.Chdir(origCwd)
+			Expect(err).To(BeNil())
 		})
 		It("no log driver should fail", func() {
 			_, stderr := getConmonOutputGivenOptions(
@@ -100,6 +105,46 @@ var _ = Describe("conmon", func() {
 				conmon.WithRuntimePath(validPath),
 			)
 			Expect(stderr).To(ContainSubstring("Log driver not provided. Use --log-path"))
+		})
+		It("empty log driver should fail", func() {
+			_, stderr := getConmonOutputGivenOptions(
+				conmon.WithPath(conmonPath),
+				conmon.WithContainerID(ctrID),
+				conmon.WithContainerUUID(ctrID),
+				conmon.WithRuntimePath(validPath),
+				conmon.WithLogPath(""),
+			)
+			Expect(stderr).To(ContainSubstring("log-path must not be empty"))
+		})
+		It("empty log driver and path should fail", func() {
+			_, stderr := getConmonOutputGivenOptions(
+				conmon.WithPath(conmonPath),
+				conmon.WithContainerID(ctrID),
+				conmon.WithContainerUUID(ctrID),
+				conmon.WithRuntimePath(validPath),
+				conmon.WithLogPath(":"),
+			)
+			Expect(stderr).To(ContainSubstring("log-path must not be empty"))
+		})
+		It("k8s-file requires a filename", func() {
+			_, stderr := getConmonOutputGivenOptions(
+				conmon.WithPath(conmonPath),
+				conmon.WithContainerID(ctrID),
+				conmon.WithContainerUUID(ctrID),
+				conmon.WithRuntimePath(validPath),
+				conmon.WithLogPath("k8s-file"),
+			)
+			Expect(stderr).To(ContainSubstring("k8s-file requires a filename"))
+		})
+		It("k8s-file: requires a filename", func() {
+			_, stderr := getConmonOutputGivenOptions(
+				conmon.WithPath(conmonPath),
+				conmon.WithContainerID(ctrID),
+				conmon.WithContainerUUID(ctrID),
+				conmon.WithRuntimePath(validPath),
+				conmon.WithLogPath("k8s-file:"),
+			)
+			Expect(stderr).To(ContainSubstring("k8s-file requires a filename"))
 		})
 		It("log driver as path should pass", func() {
 			_, stderr := getConmonOutputGivenOptions(
@@ -114,7 +159,36 @@ var _ = Describe("conmon", func() {
 			_, err := os.Stat(tmpLogPath)
 			Expect(err).To(BeNil())
 		})
+		It("log driver as k8s-file:path should pass", func() {
+			_, stderr := getConmonOutputGivenOptions(
+				conmon.WithPath(conmonPath),
+				conmon.WithContainerID(ctrID),
+				conmon.WithContainerUUID(ctrID),
+				conmon.WithRuntimePath(validPath),
+				conmon.WithLogDriver("k8s-file", tmpLogPath),
+			)
+			Expect(stderr).To(BeEmpty())
+
+			_, err := os.Stat(tmpLogPath)
+			Expect(err).To(BeNil())
+		})
+		It("log driver as :path should pass", func() {
+			_, stderr := getConmonOutputGivenOptions(
+				conmon.WithPath(conmonPath),
+				conmon.WithContainerID(ctrID),
+				conmon.WithContainerUUID(ctrID),
+				conmon.WithRuntimePath(validPath),
+				conmon.WithLogPath(":"+tmpLogPath),
+			)
+			Expect(stderr).To(BeEmpty())
+
+			_, err := os.Stat(tmpLogPath)
+			Expect(err).To(BeNil())
+		})
 		It("log driver as none should pass", func() {
+			direrr := os.Chdir(tmpDir)
+			Expect(direrr).To(BeNil())
+
 			_, stderr := getConmonOutputGivenOptions(
 				conmon.WithPath(conmonPath),
 				conmon.WithContainerID(ctrID),
@@ -123,8 +197,14 @@ var _ = Describe("conmon", func() {
 				conmon.WithLogDriver("none", ""),
 			)
 			Expect(stderr).To(BeEmpty())
+
+			_, err := os.Stat("none")
+			Expect(err).NotTo(BeNil())
 		})
 		It("log driver as off should pass", func() {
+			direrr := os.Chdir(tmpDir)
+			Expect(direrr).To(BeNil())
+
 			_, stderr := getConmonOutputGivenOptions(
 				conmon.WithPath(conmonPath),
 				conmon.WithContainerID(ctrID),
@@ -133,8 +213,14 @@ var _ = Describe("conmon", func() {
 				conmon.WithLogDriver("off", ""),
 			)
 			Expect(stderr).To(BeEmpty())
+
+			_, err := os.Stat("off")
+			Expect(err).NotTo(BeNil())
 		})
 		It("log driver as null should pass", func() {
+			direrr := os.Chdir(tmpDir)
+			Expect(direrr).To(BeNil())
+
 			_, stderr := getConmonOutputGivenOptions(
 				conmon.WithPath(conmonPath),
 				conmon.WithContainerID(ctrID),
@@ -143,8 +229,14 @@ var _ = Describe("conmon", func() {
 				conmon.WithLogDriver("null", ""),
 			)
 			Expect(stderr).To(BeEmpty())
+
+			_, err := os.Stat("none")
+			Expect(err).NotTo(BeNil())
 		})
 		It("log driver as journald should pass", func() {
+			direrr := os.Chdir(tmpDir)
+			Expect(direrr).To(BeNil())
+
 			_, stderr := getConmonOutputGivenOptions(
 				conmon.WithPath(conmonPath),
 				conmon.WithContainerID(ctrID),
@@ -153,6 +245,25 @@ var _ = Describe("conmon", func() {
 				conmon.WithLogDriver("journald", ""),
 			)
 			Expect(stderr).To(BeEmpty())
+
+			_, err := os.Stat("journald")
+			Expect(err).NotTo(BeNil())
+		})
+		It("log driver as :journald should pass", func() {
+			direrr := os.Chdir(tmpDir)
+			Expect(direrr).To(BeNil())
+
+			_, stderr := getConmonOutputGivenOptions(
+				conmon.WithPath(conmonPath),
+				conmon.WithContainerID(ctrID),
+				conmon.WithContainerUUID(ctrID),
+				conmon.WithRuntimePath(validPath),
+				conmon.WithLogPath(":journald"),
+			)
+			Expect(stderr).To(BeEmpty())
+
+			_, err := os.Stat("journald")
+			Expect(err).To(BeNil())
 		})
 		It("log driver as journald with short cid should fail", func() {
 			// conmon requires a cid of len > 12
@@ -196,7 +307,18 @@ var _ = Describe("conmon", func() {
 				conmon.WithContainerID(ctrID),
 				conmon.WithContainerUUID(ctrID),
 				conmon.WithRuntimePath(validPath),
-				conmon.WithLogDriver("invalid", tmpLogPath),
+				conmon.WithLogDriver(invalidLogDriver, tmpLogPath),
+			)
+			Expect(stderr).To(ContainSubstring("No such log driver " + invalidLogDriver))
+		})
+		It("log driver as invalid driver with a blank path should fail", func() {
+			invalidLogDriver := "invalid"
+			_, stderr := getConmonOutputGivenOptions(
+				conmon.WithPath(conmonPath),
+				conmon.WithContainerID(ctrID),
+				conmon.WithContainerUUID(ctrID),
+				conmon.WithRuntimePath(validPath),
+				conmon.WithLogDriver(invalidLogDriver, ""),
 			)
 			Expect(stderr).To(ContainSubstring("No such log driver " + invalidLogDriver))
 		})
@@ -222,7 +344,7 @@ var _ = Describe("conmon", func() {
 				conmon.WithContainerUUID(ctrID),
 				conmon.WithRuntimePath(validPath),
 				conmon.WithLogDriver("k8s-file", tmpLogPath),
-				conmon.WithLogDriver("invalid", tmpLogPath),
+				conmon.WithLogDriver(invalidLogDriver, tmpLogPath),
 			)
 			Expect(stderr).To(ContainSubstring("No such log driver " + invalidLogDriver))
 		})


### PR DESCRIPTION
When using strtok, you cannot tell if the original string had a : or not, because with

with "journald" you get driver = "journald" and path = NULL
with "journald:" you get driver = "journald" and path = NULL

That means invalid: writes to a file invalid, instead of throwing an error.
Similarly, when passing none or none: we make sure no file is written to disk.
Add debugging output for logdriver diagnostics and use in unit tests.
And "" and : just segfault.

All fixed now.