### PR TITLE
Working /dev/log proxy socket

### DIFF
--- a/05-slproxy.json
+++ b/05-slproxy.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "hook": {
+    "path": "/root/slproxy-hook"
+  },
+  "when": {
+    "always": true
+  },
+  "stages": [
+    "prestart"
+  ]
+}
+

--- a/slproxy-hook
+++ b/slproxy-hook
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+read -r -d '' SPEC
+BUNDLE=$(echo "$SPEC" |jq -r .bundle)
+CFG="${BUNDLE}/config.json"
+ID=$(echo "$SPEC" |jq -r .id)
+PID=$(echo "$SPEC" |jq -r .pid)
+ROOTPATH=$(jq -r .root.path "$CFG")
+MNTLABEL=$(jq .r .linux.mountLabel "$CFG")
+
+HASDEVLOG=$(jq -r '.mounts[] | select(.destination=="/dev/log") ' "$CFG")
+if [ -e "$BUNDLE/slproxy" ] && [ -z "$HASDEVLOG" ]; then
+  nsenter --target $PID --mount touch "$ROOTPATH/dev/log"
+  nsenter --target $PID --mount mount --bind "$BUNDLE/slproxy" "$ROOTPATH/dev/log" -o rw,rprivate,nosuid,nodev,rbind,mode=666${MNTLABEL:+,context="$MNTLABEL"}
+fi

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -174,6 +174,7 @@ int main(int argc, char *argv[])
 	_cleanup_free_ char *attach_symlink_dir_path = NULL;
 	if (opt_bundle_path != NULL) {
 		attach_symlink_dir_path = setup_attach_socket();
+		setup_syslog_proxy_socket();
 		dummyfd = setup_terminal_control_fifo();
 		setup_console_fifo();
 

--- a/src/conn_sock.h
+++ b/src/conn_sock.h
@@ -17,6 +17,7 @@ struct conn_sock_s {
 
 char *setup_console_socket(void);
 char *setup_attach_socket(void);
+char *setup_syslog_proxy_socket(void);
 void conn_sock_shutdown(struct conn_sock_s *sock, int how);
 void schedule_master_stdin_write();
 


### PR DESCRIPTION
Has conmon listen on bundle/slproxy, uses a provided OCI hook example to bind-mount that as /dev/log in the container.  Conmon reads datagrams and writes them back out to the host /dev/log.

Probably needs some more testing - i.e. if /dev/log is deleted and recreated, making sure we don't end up in a write infinite loop.. Also, organizational comments welcome.  Should this be a log-driver option? (one compounded with other such options). Should this be in ctr_logging?  It's in conn_sock because that's where most of the code that was similar to this use case was located.  Or should it be its own .c?
