### PR TITLE
conmon: drop fsync calls

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -426,8 +426,6 @@ int main(int argc, char *argv[])
 	if (!timed_out)
 		drain_stdio();
 
-	sync_logs();
-
 	int exit_status = -1;
 	const char *exit_message = NULL;
 

--- a/src/ctr_logging.c
+++ b/src/ctr_logging.c
@@ -489,11 +489,6 @@ static void reopen_k8s_file(void)
 
 	_cleanup_free_ char *k8s_log_path_tmp = g_strdup_printf("%s.tmp", k8s_log_path);
 
-	/* Sync the logs to disk */
-	if (fsync(k8s_log_fd) < 0) {
-		pwarn("Failed to sync log file on reopen");
-	}
-
 	/* Close the current k8s_log_fd */
 	close(k8s_log_fd);
 
@@ -506,13 +501,4 @@ static void reopen_k8s_file(void)
 	if (rename(k8s_log_path_tmp, k8s_log_path) < 0) {
 		pexit("Failed to rename log file");
 	}
-}
-
-
-void sync_logs(void)
-{
-	/* Sync the logs to disk */
-	if (k8s_log_fd > 0)
-		if (fsync(k8s_log_fd) < 0)
-			pwarn("Failed to sync log file before exit");
 }


### PR DESCRIPTION
on a crash, CRI-O completely wipes out the entire storage so there is
no need on syncing the log files.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>