### PR TITLE
nix run -f channel:nixos-20.03

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -230,12 +230,18 @@ static_binary_task:
         - 'config'
         - 'fmt'
     gce_instance:
-        image_name: "${FEDORA_BASE_IMAGE}"
-        cpu: 4
-        memory: 4
+        image_name: "${FEDORA_CACHE_IMAGE_NAME}"
+        cpu: 8
+        memory: 12
         disk: 200
-    script:
-        - dnf install -y podman make git gcc
-        - make containerized
+    script: |
+        set -ex
+        setenforce 0
+        growpart /dev/sda 1 || true
+        resize2fs /dev/sda1 || true
+        yum -y install podman
+        mkdir -p /nix
+        podman run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix
+        podman run --rm --privileged -ti -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
     binaries_artifacts:
-        path: "bin/conmon"
+        path: "result/bin/conmon"

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,10 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "0f114432d4a9399e0b225d5be1599c7ebc5e2772",
-  "date": "2020-05-29T19:54:08-05:00",
-  "path": "/nix/store/ds31sjj3ppsk0xclkficx9p3w6qslmdc-nixpkgs",
-  "sha256": "1qd2dlc5dk98y0xdahv9k72ibv5dsy10jg25xqvj38sadxbs3g0j",
-  "fetchSubmodules": false,
-  "deepClone": false,
-  "leaveDotGit": false
+  "rev": "02591d02a910b3b92092153c5f3419a8d696aa1d",
+  "date": "2020-07-09T03:52:28+02:00",
+  "sha256": "1pp9v4rqmgx1b298gxix8b79m8pvxy1rcf8l25rxxxxnkr5ls1ng",
+  "fetchSubmodules": false
 }


### PR DESCRIPTION
@saschagrunert Once I update with `make nixpkgs` for https://github.com/containers/conmon/releases/tag/v2.0.18, I found the compile with `nix build -f nix/` will failed as below:
```
builder for '/nix/store/yvrx4c696ahd3xnf92111a66ddys9i93-gnutls-3.6.14.drv' failed with exit code 2; last 10 log lines:
  collect2: error: ld returned 1 exit status
  make[4]: *** [Makefile:2184: certtool] Error 1
  make[4]: Leaving directory '/tmp/nix-build-gnutls-3.6.14.drv-0/gnutls-3.6.14/src'
  make[3]: *** [Makefile:2383: all-recursive] Error 1
  make[3]: Leaving directory '/tmp/nix-build-gnutls-3.6.14.drv-0/gnutls-3.6.14/src'
  make[2]: *** [Makefile:2044: all] Error 2
  make[2]: Leaving directory '/tmp/nix-build-gnutls-3.6.14.drv-0/gnutls-3.6.14/src'
  make[1]: *** [Makefile:1757: all-recursive] Error 1
  make[1]: Leaving directory '/tmp/nix-build-gnutls-3.6.14.drv-0/gnutls-3.6.14'
  make: *** [Makefile:1682: all] Error 2
cannot build derivation '/nix/store/ilblg72d139fl097ylfxd59prsb47r67-libmicrohttpd-0.9.70.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/pplxxisi9l0r9faja8d9xswhn2n4ldm9-systemd-245.5.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/x1i7cj73paqqj05xk92lcwy1k4q19px2-conmon.drv': 1 dependencies couldn't be built
[0 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/x1i7cj73paqqj05xk92lcwy1k4q19px2-conmon.drv' failed
```

This also failed for v2.0.18. Seems like upstream nixpkgs bugs?