### PR TITLE
Reap PIDs before running exit command

### DIFF
--- a/src/ctr_exit.c
+++ b/src/ctr_exit.c
@@ -142,6 +142,11 @@ void do_exit_command()
 		_pexit("Failed to reset signal for SIGCHLD");
 	}
 
+	/* We need to reap any zombies (from an OCI runtime that errored) before
+	   running it. */
+	while (waitpid(-1, NULL, WNOHANG) > 0)
+		;
+
 	pid_t exit_pid = fork();
 	if (exit_pid < 0) {
 		_pexit("Failed to fork");


### PR DESCRIPTION
This was first noticed when running Podman when using the exit command delay functionality. When the OCI runtime exits with an error, there are some cases where Conmon will exit without reaping it; thus, we were ending up with a zombie that persisted until the exit command completed and exited. We didn't notice this before because the exit command only took a second or two so the zombie's lifetime was very short, since it would reparent and be reaped once Conmon died. With exit-delay, though, we could be leaving a zombie around for hundreds of seconds, and this means we cannot kill the container during this period.