### PR TITLE
Refactor I/O and add SD_NOTIFY proxy support

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -48,6 +48,7 @@ char *opt_log_level = NULL;
 char *opt_log_tag = NULL;
 gboolean opt_sync = FALSE;
 gboolean opt_no_sync_log = FALSE;
+char *opt_sdnotify_socket = NULL;
 GOptionEntry opt_entries[] = {
 	{"terminal", 't', 0, G_OPTION_ARG_NONE, &opt_terminal, "Terminal", NULL},
 	{"stdin", 'i', 0, G_OPTION_ARG_NONE, &opt_stdin, "Stdin", NULL},
@@ -93,6 +94,8 @@ GOptionEntry opt_entries[] = {
 	{"log-tag", 0, 0, G_OPTION_ARG_STRING, &opt_log_tag, "Additional tag to use for logging", NULL},
 	{"no-sync-log", 0, 0, G_OPTION_ARG_NONE, &opt_no_sync_log, "Do not manually call sync on logs after container shutdown", NULL},
 	{"sync", 0, 0, G_OPTION_ARG_NONE, &opt_sync, "Allowing caller to keep the main conmon process as its child by only forking once",
+	 NULL},
+	{"sdnotify-socket", 0, 0, G_OPTION_ARG_STRING, &opt_sdnotify_socket, "Path to the host's sd-notify socket to relay messages to",
 	 NULL},
 	{NULL, 0, 0, 0, NULL, NULL, NULL}};
 

--- a/src/cli.h
+++ b/src/cli.h
@@ -42,6 +42,7 @@ extern char *opt_log_level;
 extern char *opt_log_tag;
 extern gboolean opt_no_sync_log;
 extern gboolean opt_sync;
+extern char *opt_sdnotify_socket;
 extern GOptionEntry opt_entries[];
 
 int initialize_cli(int argc, char *argv[]);

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -89,6 +89,11 @@ int main(int argc, char *argv[])
 	/* before we fork, ensure our children will be reaped */
 	atexit(reap_children);
 
+	/* If we were passed a sd-notify socket to use, set it up now */
+	if (opt_sdnotify_socket) {
+		setup_notify_socket(opt_sdnotify_socket);
+	}
+
 	/* Environment variables */
 	sync_pipe_fd = get_pipe_fd_from_env("_OCI_SYNCPIPE");
 

--- a/src/conn_sock.h
+++ b/src/conn_sock.h
@@ -4,9 +4,33 @@
 #include <glib.h>   /* gboolean */
 #include "config.h" /* CONN_SOCK_BUF_SIZE */
 
+#define SOCK_TYPE_CONSOLE 1
+#define SOCK_TYPE_NOTIFY 2
+#define SOCK_IS_CONSOLE(sock_type) ((sock_type) == SOCK_TYPE_CONSOLE)
+#define SOCK_IS_NOTIFY(sock_type) ((sock_type) == SOCK_TYPE_NOTIFY)
+#define SOCK_IS_STREAM(sock_type) ((sock_type) == SOCK_TYPE_CONSOLE)
+#define SOCK_IS_DGRAM(sock_type) ((sock_type) != SOCK_TYPE_CONSOLE)
+
 /* Used for attach */
-struct conn_sock_s {
+/* The nomenclature here is decided but may not be entirely intuitive.
+   in_sock and out_sock doesn't seem right, because ctr_stdio
+   breaks encapsulation and writes directly to the console
+   sockets.
+   In most cases in conn_sock.c, this struct is "INPUT" and
+   the next one is "OUTPUT".  Really it's this struct is "one"
+   and the next is "many", but I don't want the same fd in
+   two different sockets.
+
+   "remote" indicates "Remote User" i.e. attached console, or
+       "container's /dev/log" or "container's /run/notify"
+   "local"  incidates "A socket we own, locally" i.e. mainfd_stdin
+      or "host /dev/log" or "host /run/systemd/notify"
+  */
+struct remote_sock_s {
+	int sock_type;
 	int fd;
+	struct local_sock_s *dest;
+	gboolean listening;
 	gboolean data_ready;
 	gboolean readable;
 	gboolean writable;
@@ -15,9 +39,18 @@ struct conn_sock_s {
 	char buf[CONN_SOCK_BUF_SIZE];
 };
 
+struct local_sock_s {
+	int *fd;
+	gboolean is_stream;
+	GPtrArray *readers;
+	char *label;
+	struct sockaddr_un *addr;
+};
+
 char *setup_console_socket(void);
 char *setup_attach_socket(void);
-void conn_sock_shutdown(struct conn_sock_s *sock, int how);
+void setup_notify_socket(char *);
 void schedule_main_stdin_write();
+void write_back_to_remote_consoles(char *buf, int len);
 
 #endif // CONN_SOCK_H

--- a/src/ctr_stdio.c
+++ b/src/ctr_stdio.c
@@ -107,7 +107,6 @@ static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof)
 	char real_buf[STDIO_BUF_SIZE + 2];
 	char *buf = real_buf + 1;
 	ssize_t num_read = 0;
-	size_t i;
 
 	if (eof)
 		*eof = false;
@@ -128,19 +127,8 @@ static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof)
 		if (!written)
 			return written;
 
-		if (conn_socks == NULL) {
-			return true;
-		}
-
 		real_buf[0] = pipe;
-		for (i = conn_socks->len; i > 0; i--) {
-			struct conn_sock_s *conn_sock = g_ptr_array_index(conn_socks, i - 1);
-
-			if (conn_sock->writable && write_all(conn_sock->fd, real_buf, num_read + 1) < 0) {
-				nwarn("Failed to write to socket");
-				conn_sock_shutdown(conn_sock, SHUT_WR);
-			}
-		}
+		write_back_to_remote_consoles(real_buf, num_read + 1);
 		return true;
 	}
 }

--- a/src/globals.c
+++ b/src/globals.c
@@ -7,8 +7,6 @@ int mainfd_stdin = -1;
 int mainfd_stdout = -1;
 int mainfd_stderr = -1;
 
-GPtrArray *conn_socks = NULL;
-
 int attach_socket_fd = -1;
 int console_socket_fd = -1;
 int terminal_ctrl_fd = -1;

--- a/src/globals.h
+++ b/src/globals.h
@@ -12,8 +12,6 @@ extern int mainfd_stdin;
 extern int mainfd_stdout;
 extern int mainfd_stderr;
 
-extern GPtrArray *conn_socks;
-
 extern int attach_socket_fd;
 extern int console_socket_fd;
 extern int terminal_ctrl_fd;


### PR DESCRIPTION
Refactored all the conn_sock functionality to be more generic. It can deal
with different types of sockets, stream vs dgram, and reuses all the same
callbacks, shutdown and async functionality.

Conmon creates a notify socket which podman bind-mounts into the container,
and passes in via the spec's environment variables.  Conmon relays the
READY=1 signal.  This is similar to what runc and crun do, but doing it in
conmon and NOT passing NOTIFY_SOCKET to the OCI runtime allows us to start
up properly without runc and crun blocking on the "start" command.

It would also be trivial to add more proxied sockets, i.e. the /dev/log
proof of concept I did would now be super easy, if we wanted to revisit that.

Signed-off-by: Joseph Gooch <mrwizard@dok.org>