### PR TITLE
add options to handle children differently

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ container manager (like [Podman](https://podman.io/) or
 [runc](https://github.com/opencontainers/runc) or
 [crun](https://github.com/containers/crun)) for a single container.
 
-Upon being launched, it double-forks to daemonize and detach from the
+Upon being launched, conmon (usually) double-forks to daemonize and detach from the
 parent that launched it. It then launches the runtime as its child. This
 allows managing processes to die in the foreground, but still be able to
 watch over and connect to the child process (the container).

--- a/src/cli.c
+++ b/src/cli.c
@@ -46,6 +46,7 @@ int opt_exit_delay = 0;
 gboolean opt_replace_listen_pid = FALSE;
 char *opt_log_level = NULL;
 char *opt_log_tag = NULL;
+gboolean opt_sync = FALSE;
 GOptionEntry opt_entries[] = {
 	{"terminal", 't', 0, G_OPTION_ARG_NONE, &opt_terminal, "Terminal", NULL},
 	{"stdin", 'i', 0, G_OPTION_ARG_NONE, &opt_stdin, "Stdin", NULL},
@@ -89,6 +90,8 @@ GOptionEntry opt_entries[] = {
 	{"syslog", 0, 0, G_OPTION_ARG_NONE, &opt_syslog, "Log to syslog (use with cgroupfs cgroup manager)", NULL},
 	{"log-level", 0, 0, G_OPTION_ARG_STRING, &opt_log_level, "Print debug logs based on log level", NULL},
 	{"log-tag", 0, 0, G_OPTION_ARG_STRING, &opt_log_tag, "Additional tag to use for logging", NULL},
+	{"sync", 0, 0, G_OPTION_ARG_NONE, &opt_sync, "Allowing caller to keep the main conmon process as its child by only forking once",
+	 NULL},
 	{NULL, 0, 0, 0, NULL, NULL, NULL}};
 
 

--- a/src/cli.h
+++ b/src/cli.h
@@ -40,6 +40,7 @@ extern int opt_exit_delay;
 extern gboolean opt_replace_listen_pid;
 extern char *opt_log_level;
 extern char *opt_log_tag;
+extern gboolean opt_sync;
 extern GOptionEntry opt_entries[];
 
 int initialize_cli(int argc, char *argv[]);

--- a/src/ctr_exit.h
+++ b/src/ctr_exit.h
@@ -23,5 +23,6 @@ int get_exit_status(int status);
 void runtime_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointer user_data);
 void container_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointer user_data);
 void do_exit_command();
+void reap_children();
 
 #endif // CTR_EXIT_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -43,6 +43,14 @@ extern gboolean use_syslog;
 		_exit(EXIT_FAILURE); \
 	} while (0)
 
+#define _pexitf(fmt, ...) \
+	do { \
+		fprintf(stderr, "[conmon:e]: " fmt " %s\n", ##__VA_ARGS__, strerror(errno)); \
+		if (use_syslog) \
+			syslog(LOG_ERR, "conmon %.20s <error>: " fmt ": %s\n", log_cid, ##__VA_ARGS__, strerror(errno)); \
+		_exit(EXIT_FAILURE); \
+	} while (0)
+
 #define pexit(s) \
 	do { \
 		fprintf(stderr, "[conmon:e]: %s %s\n", s, strerror(errno)); \


### PR DESCRIPTION
This includes:
unconditionally reap children as it doesn't hurt, and we've seen cases where the children are not cleaned up after a clean exit (causing excess load for systemd)
add --sync to allow conmon to only fork once, allowing the caller to have fewer children
also, make sure we don't call atexit callbacks for failed children after fork() by replacing calls to pexit() with _pexit()

Signed-off-by: Peter Hunt <pehunt@redhat.com>