### PR TITLE
logs: readd sync, but gate behavior on cli flag

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -47,6 +47,7 @@ gboolean opt_replace_listen_pid = FALSE;
 char *opt_log_level = NULL;
 char *opt_log_tag = NULL;
 gboolean opt_sync = FALSE;
+gboolean opt_no_sync_log = FALSE;
 GOptionEntry opt_entries[] = {
 	{"terminal", 't', 0, G_OPTION_ARG_NONE, &opt_terminal, "Terminal", NULL},
 	{"stdin", 'i', 0, G_OPTION_ARG_NONE, &opt_stdin, "Stdin", NULL},
@@ -90,6 +91,7 @@ GOptionEntry opt_entries[] = {
 	{"syslog", 0, 0, G_OPTION_ARG_NONE, &opt_syslog, "Log to syslog (use with cgroupfs cgroup manager)", NULL},
 	{"log-level", 0, 0, G_OPTION_ARG_STRING, &opt_log_level, "Print debug logs based on log level", NULL},
 	{"log-tag", 0, 0, G_OPTION_ARG_STRING, &opt_log_tag, "Additional tag to use for logging", NULL},
+	{"no-sync-log", 0, 0, G_OPTION_ARG_NONE, &opt_no_sync_log, "Do not manually call sync on logs after container shutdown", NULL},
 	{"sync", 0, 0, G_OPTION_ARG_NONE, &opt_sync, "Allowing caller to keep the main conmon process as its child by only forking once",
 	 NULL},
 	{NULL, 0, 0, 0, NULL, NULL, NULL}};

--- a/src/cli.h
+++ b/src/cli.h
@@ -40,6 +40,7 @@ extern int opt_exit_delay;
 extern gboolean opt_replace_listen_pid;
 extern char *opt_log_level;
 extern char *opt_log_tag;
+extern gboolean opt_no_sync_log;
 extern gboolean opt_sync;
 extern GOptionEntry opt_entries[];
 

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -431,6 +431,9 @@ int main(int argc, char *argv[])
 	if (!timed_out)
 		drain_stdio();
 
+	if (!opt_no_sync_log)
+		sync_logs();
+
 	int exit_status = -1;
 	const char *exit_message = NULL;
 


### PR DESCRIPTION
this allows callers to keep backward compatibility (if they rely on the sync) but new users to drop the sync if they'd like

Signed-off-by: Peter Hunt <pehunt@redhat.com>