### PR TITLE
Speedup static build by utilizing CI cache on `/nix` folder

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,19 +135,33 @@ static_binary_task:
     depends_on:
         - 'config'
         - 'fmt'
+
     gce_instance:
         image_name: "${FEDORA_CACHE_IMAGE_NAME}"
         cpu: 8
         memory: 12
         disk: 200
-    script: |
+
+    init_script: |
         set -ex
         setenforce 0
         growpart /dev/sda 1 || true
         resize2fs /dev/sda1 || true
         yum -y install podman
-        mkdir -p /nix
-        podman run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix
+
+    nix_cache:
+      folder: '.cache'
+      fingerprint_script: |
+        echo "nix-v1-$(sha1sum nix/nixpkgs.json | head -c 40)"
+
+    build_script: |
+        set -ex
+        mkdir -p .cache
+        mv .cache /nix
+        if [[ -z $(ls -A /nix) ]]; then podman run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
         podman run --rm --privileged -ti -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
+        mv /nix .cache
+        chown -Rf $(whoami) .cache
+
     binaries_artifacts:
         path: "result/bin/conmon"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,6 +11,7 @@ let
     config = {
       packageOverrides = pkg: {
         autogen = (static pkg.autogen);
+        e2fsprogs = (static pkg.e2fsprogs);
         glib = (static pkg.glib).overrideAttrs(x: {
           outputs = [ "bin" "out" "dev" ];
           mesonFlags = [

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "02591d02a910b3b92092153c5f3419a8d696aa1d",
-  "date": "2020-07-09T03:52:28+02:00",
-  "sha256": "1pp9v4rqmgx1b298gxix8b79m8pvxy1rcf8l25rxxxxnkr5ls1ng",
+  "rev": "5f212d693fe1c82f9c7e20cd57bc69802b36a321",
+  "date": "2020-08-22T01:42:23+02:00",
+  "sha256": "1h3819ppllcpw07j884bjh07sma07vrrk1md92sf93cg43nmzncf",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Also see:
- https://github.com/containers/crun/pull/428
- https://github.com/containers/conmon/pull/189
- https://github.com/containers/skopeo/pull/973
- https://github.com/containers/buildah/pull/2428
- https://github.com/containers/podman/pull/7076
- https://github.com/cri-o/cri-o/pull/4012

Signed-off-by: Wong Hoi Sing Edison <hswong3i@gmail.com>