### PR TITLE
seccomp: add support for seccomp notify

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,7 +73,7 @@ fedora_packaging_task:
             image: "${PRIOR_FEDORA_CONTAINER_FQIN}"
 
     script:
-        - dnf install -y rpm-build golang
+        - dnf install -y rpm-build golang libseccomp-devel
         - cd $CIRRUS_WORKING_DIR
         - make
         - make -f .rpmbuild/Makefile

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -123,7 +123,7 @@ static_binary_task:
     # the next line and file an issue with details about the failure.
     # allow_failures: true
 
-    timeout_in: '20m'
+    timeout_in: '120m'
 
     gce_instance:
         image_name: "${FEDORA_CACHE_IMAGE_NAME}"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ GO ?= go
 PROJECT := github.com/containers/conmon
 PKG_CONFIG ?= pkg-config
 HEADERS := $(wildcard src/*.h)
-OBJS := src/conmon.o src/cmsg.o src/ctr_logging.o src/utils.o src/cli.o src/globals.o src/cgroup.o src/conn_sock.o src/oom.o src/ctrl.o src/ctr_stdio.o src/parent_pipe_fd.o src/ctr_exit.o src/runtime_args.o src/close_fds.o
+
+OBJS := src/conmon.o src/cmsg.o src/ctr_logging.o src/utils.o src/cli.o src/globals.o src/cgroup.o src/conn_sock.o src/oom.o src/ctrl.o src/ctr_stdio.o src/parent_pipe_fd.o src/ctr_exit.o src/runtime_args.o src/close_fds.o src/seccomp_notify.o
 
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -43,6 +44,13 @@ ifeq ($(shell $(PKG_CONFIG) --exists libsystemd-journal && echo "0" || echo "1")
 else ifeq ($(shell $(PKG_CONFIG) --exists libsystemd && echo "0" || echo "1"), 0)
 	override LIBS += $(shell $(PKG_CONFIG) --libs libsystemd)
 	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libsystemd) -D USE_JOURNALD=0
+endif
+
+ifeq ($(shell $(PKG_CONFIG) --exists libseccomp && echo "0" || echo "1"), 0)
+	override LIBS += $(shell $(PKG_CONFIG) --libs libseccomp) -ldl
+	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libseccomp) -D USE_SECCOMP=1
+else
+	override CFLAGS += -D USE_SECCOMP=0
 endif
 
 # Update nix/nixpkgs.json its latest stable commit

--- a/contrib/spec/conmon.spec.in
+++ b/contrib/spec/conmon.spec.in
@@ -22,6 +22,7 @@ ExclusiveArch: aarch64 %{arm} ppc64le s390x x86_64
 BuildRequires: gcc
 BuildRequires: glib2-devel
 BuildRequires: glibc-devel
+BuildRequires: libseccomp-devel
 BuildRequires: git
 # If go_compiler is not set to 1, there is no virtual provide. Use golang instead.
 BuildRequires: golang

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,7 @@ add_project_arguments('-Os', '-Wall', '-Werror',
                       language : 'c')
 
 glib = dependency('glib-2.0')
+libdl = cc.find_library('dl')
 
 executable('conmon',
            ['src/conmon.c',
@@ -67,8 +68,10 @@ executable('conmon',
             'src/runtime_args.c',
             'src/runtime_args.h',
             'src/utils.c',
-            'src/utils.h'],
-           dependencies : [glib],
+            'src/utils.h',
+            'src/seccomp_notify.c',
+            'src/seccomp_notify.h'],
+           dependencies : [glib, libdl],
            install : true,
            install_dir : join_paths(get_option('libexecdir'), 'podman'),
 )

--- a/nix/default-arm64.nix
+++ b/nix/default-arm64.nix
@@ -17,6 +17,7 @@ let
         autogen = (static pkg.autogen);
         e2fsprogs = (static pkg.e2fsprogs);
         libuv = (static pkg.libuv);
+        libseccomp = (static pkg.libseccomp);
         glib = (static pkg.glib).overrideAttrs (x: {
           outputs = [ "bin" "out" "dev" ];
           mesonFlags = [
@@ -77,7 +78,7 @@ let
       pkg-config
       which
     ];
-    buildInputs = [ glibc glibc.static glib ];
+    buildInputs = [ glibc glibc.static glib libseccomp ];
     prePatch = ''
       export CFLAGS='-static -pthread'
       export LDFLAGS='-s -w -static-libgcc -static'

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,6 +13,7 @@ let
         autogen = (static pkg.autogen);
         e2fsprogs = (static pkg.e2fsprogs);
         libuv = (static pkg.libuv);
+        libseccomp = (static pkg.libseccomp);
         glib = (static pkg.glib).overrideAttrs(x: {
           outputs = [ "bin" "out" "dev" ];
           mesonFlags = [
@@ -60,7 +61,7 @@ let
     enableParallelBuilding = true;
     outputs = [ "out" ];
     nativeBuildInputs = [ bash gitMinimal pcre pkg-config which ];
-    buildInputs = [ glibc glibc.static glib ];
+    buildInputs = [ glibc glibc.static glib libseccomp ];
     prePatch = ''
       export CFLAGS='-static -pthread'
       export LDFLAGS='-s -w -static-libgcc -static'

--- a/src/cli.c
+++ b/src/cli.c
@@ -50,6 +50,8 @@ gboolean opt_sync = FALSE;
 gboolean opt_no_sync_log = FALSE;
 char *opt_sdnotify_socket = NULL;
 gboolean opt_full_attach_path = FALSE;
+char *opt_seccomp_notify_socket = NULL;
+char *opt_seccomp_notify_plugins = NULL;
 GOptionEntry opt_entries[] = {
 	{"api-version", 0, 0, G_OPTION_ARG_NONE, &opt_api_version, "Conmon API version to use", NULL},
 	{"bundle", 'b', 0, G_OPTION_ARG_STRING, &opt_bundle_path, "Location of the OCI Bundle path", NULL},
@@ -100,6 +102,10 @@ GOptionEntry opt_entries[] = {
 	{"version", 0, 0, G_OPTION_ARG_NONE, &opt_version, "Print the version and exit", NULL},
 	{"full-attach", 0, 0, G_OPTION_ARG_NONE, &opt_full_attach_path,
 	 "Don't truncate the path to the attach socket. This option causes conmon to ignore --socket-dir-path", NULL},
+	{"seccomp-notify-socket", 0, 0, G_OPTION_ARG_STRING, &opt_seccomp_notify_socket,
+	 "Path to the socket where the seccomp notification fd is received", NULL},
+	{"seccomp-notify-plugins", 0, 0, G_OPTION_ARG_STRING, &opt_seccomp_notify_plugins,
+	 "Plugins to use for managing the seccomp notifications", NULL},
 	{NULL, 0, 0, 0, NULL, NULL, NULL}};
 
 
@@ -149,6 +155,9 @@ void process_cli()
 	/* The old exec API did not require opt_cuuid */
 	if (opt_cuuid == NULL && (!opt_exec || opt_api_version >= 1))
 		nexit("Container UUID not provided. Use --cuuid");
+
+	if (opt_seccomp_notify_plugins == NULL)
+		opt_seccomp_notify_plugins = getenv("CONMON_SECCOMP_NOTIFY_PLUGINS");
 
 	if (opt_runtime_path == NULL)
 		nexit("Runtime path not provided. Use --runtime");

--- a/src/cli.h
+++ b/src/cli.h
@@ -43,6 +43,8 @@ extern char *opt_log_tag;
 extern gboolean opt_no_sync_log;
 extern gboolean opt_sync;
 extern char *opt_sdnotify_socket;
+extern char *opt_seccomp_notify_socket;
+extern char *opt_seccomp_notify_plugins;
 extern GOptionEntry opt_entries[];
 extern gboolean opt_full_attach_path;
 

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -18,6 +18,7 @@
 #include "parent_pipe_fd.h"
 #include "ctr_exit.h"
 #include "close_fds.h"
+#include "seccomp_notify.h"
 #include "runtime_args.h"
 
 #include <sys/prctl.h>
@@ -133,6 +134,7 @@ int main(int argc, char *argv[])
 	}
 
 	_cleanup_free_ char *csname = NULL;
+	_cleanup_free_ char *seccomp_listener = NULL;
 	int workerfd_stdin = -1;
 	int workerfd_stdout = -1;
 	int workerfd_stderr = -1;
@@ -173,6 +175,15 @@ int main(int argc, char *argv[])
 		 * a negative fd, and fail to resize the window */
 		if (winsz_fd_r >= 0)
 			g_unix_fd_add(winsz_fd_r, G_IO_IN, ctrl_winsz_cb, NULL);
+	}
+
+	if (opt_seccomp_notify_socket != NULL) {
+#if !USE_SECCOMP
+		pexit("seccomp support not present");
+#endif
+		if (opt_seccomp_notify_plugins == NULL)
+			pexit("seccomp notify socket specified without any plugin");
+		seccomp_listener = setup_seccomp_socket(opt_seccomp_notify_socket);
 	}
 
 	/* We always create a stderr pipe, because that way we can capture
@@ -316,6 +327,9 @@ int main(int argc, char *argv[])
 		close(workerfd_stdout);
 	if (workerfd_stderr > -1)
 		close(workerfd_stderr);
+
+	if (seccomp_listener != NULL)
+		g_unix_fd_add(seccomp_socket_fd, G_IO_IN, seccomp_accept_cb, csname);
 
 	if (csname != NULL) {
 		g_unix_fd_add(console_socket_fd, G_IO_IN, terminal_accept_cb, csname);
@@ -490,6 +504,8 @@ int main(int argc, char *argv[])
 		if (!g_file_set_contents(exit_file_path, status_str, -1, &err))
 			nexitf("Failed to write %s to exit file: %s", status_str, err->message);
 	}
+	if (seccomp_listener != NULL)
+		unlink(seccomp_listener);
 
 	/* Send the command exec exit code back to the parent */
 	if (opt_exec && sync_pipe_fd >= 0)

--- a/src/conn_sock.h
+++ b/src/conn_sock.h
@@ -48,6 +48,7 @@ struct local_sock_s {
 };
 
 char *setup_console_socket(void);
+char *setup_seccomp_socket(const char *socket);
 char *setup_attach_socket(void);
 void setup_notify_socket(char *);
 void schedule_main_stdin_write();

--- a/src/ctrl.c
+++ b/src/ctrl.c
@@ -8,6 +8,7 @@
 #include "conn_sock.h"
 #include "cmsg.h"
 #include "cli.h" // opt_bundle_path
+#include "seccomp_notify.h"
 
 #include <sys/ioctl.h>
 #include <sys/socket.h>

--- a/src/globals.c
+++ b/src/globals.c
@@ -9,6 +9,7 @@ int mainfd_stderr = -1;
 
 int attach_socket_fd = -1;
 int console_socket_fd = -1;
+int seccomp_socket_fd = -1;
 int terminal_ctrl_fd = -1;
 int inotify_fd = -1;
 int winsz_fd_w = -1;

--- a/src/globals.h
+++ b/src/globals.h
@@ -14,6 +14,7 @@ extern int mainfd_stderr;
 
 extern int attach_socket_fd;
 extern int console_socket_fd;
+extern int seccomp_socket_fd;
 extern int terminal_ctrl_fd;
 extern int inotify_fd;
 extern int winsz_fd_w;

--- a/src/seccomp_notify.c
+++ b/src/seccomp_notify.c
@@ -1,0 +1,328 @@
+#define _GNU_SOURCE
+#if __STDC_VERSION__ >= 199901L
+/* C99 or later */
+#else
+#error conmon.c requires C99 or later
+#endif
+
+#include <errno.h>
+#include <seccomp.h>
+#include <sys/ioctl.h>
+#include <linux/seccomp.h>
+#include <sys/sysmacros.h>
+#include <dlfcn.h>
+#include <sys/wait.h>
+#include <sys/mount.h>
+#include <signal.h>
+#include <sys/socket.h>
+
+#include "cli.h" // opt_bundle_path
+#include "utils.h"
+#include "cmsg.h"
+#include "seccomp_notify.h"
+
+#ifndef SECCOMP_USER_NOTIF_FLAG_CONTINUE
+#define SECCOMP_USER_NOTIF_FLAG_CONTINUE (1UL << 0)
+#endif
+
+static struct seccomp_notify_context_s *seccomp_notify_ctx;
+
+struct plugin {
+	void *handle;
+	void *opaque;
+	run_oci_seccomp_notify_handle_request_cb handle_request_cb;
+};
+
+struct seccomp_notify_context_s {
+	struct plugin *plugins;
+	size_t n_plugins;
+
+#if USE_SECCOMP
+	struct seccomp_notif_resp *sresp;
+	struct seccomp_notif *sreq;
+	struct seccomp_notif_sizes sizes;
+#endif
+};
+
+static inline void *xmalloc0(size_t size);
+static void cleanup_seccomp_plugins();
+
+#if USE_SECCOMP
+static int seccomp_syscall(unsigned int op, unsigned int flags, void *args);
+#endif
+
+gboolean seccomp_cb(int fd, GIOCondition condition, G_GNUC_UNUSED gpointer user_data)
+{
+	if (condition & G_IO_IN) {
+		if (seccomp_notify_ctx == NULL)
+			return G_SOURCE_REMOVE;
+
+		int ret = seccomp_notify_plugins_event(seccomp_notify_ctx, fd);
+		return ret == 0 ? G_SOURCE_CONTINUE : G_SOURCE_REMOVE;
+	}
+	return G_SOURCE_CONTINUE;
+}
+
+gboolean seccomp_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC_UNUSED gpointer user_data)
+{
+	ninfof("about to accept from seccomp_socket_fd: %d", fd);
+	int connfd = accept4(fd, NULL, NULL, SOCK_CLOEXEC);
+	if (connfd < 0) {
+		nwarn("Failed to accept console-socket connection");
+		return G_SOURCE_CONTINUE;
+	}
+
+	struct file_t listener = recvfd(connfd);
+	close(connfd);
+
+	_cleanup_free_ char *oci_config_path = g_strdup_printf("%s/config.json", opt_bundle_path);
+	if (oci_config_path == NULL) {
+		nwarn("Failed to allocate memory");
+		return G_SOURCE_CONTINUE;
+	}
+
+	struct seccomp_notify_conf_s conf = {
+		.runtime_root_path = NULL,
+		.name = opt_name,
+		.bundle_path = opt_bundle_path,
+		.oci_config_path = oci_config_path,
+	};
+	int ret = seccomp_notify_plugins_load(&seccomp_notify_ctx, opt_seccomp_notify_plugins, &conf);
+	if (ret < 0) {
+		nwarn("Failed to initialize seccomp notify plugins");
+		return G_SOURCE_CONTINUE;
+	}
+
+	g_unix_set_fd_nonblocking(listener.fd, TRUE, NULL);
+	g_unix_fd_add(listener.fd, G_IO_IN | G_IO_HUP, seccomp_cb, NULL);
+	atexit(cleanup_seccomp_plugins);
+
+	return G_SOURCE_CONTINUE;
+}
+
+#if USE_SECCOMP
+int seccomp_notify_plugins_load(struct seccomp_notify_context_s **out, const char *plugins, struct seccomp_notify_conf_s *conf)
+{
+	cleanup_seccomp_notify_context struct seccomp_notify_context_s *ctx = xmalloc0(sizeof *ctx);
+	_cleanup_free_ char *b = NULL;
+	char *it, *saveptr;
+	size_t s;
+
+	if (seccomp_syscall(SECCOMP_GET_NOTIF_SIZES, 0, &ctx->sizes) < 0) {
+		pexit("Failed to get notifications size");
+		return -1;
+	}
+
+	ctx->sreq = xmalloc0(ctx->sizes.seccomp_notif);
+	ctx->sresp = xmalloc0(ctx->sizes.seccomp_notif_resp);
+
+	ctx->n_plugins = 1;
+	for (it = b; it; it = strchr(it, ':'))
+		ctx->n_plugins++;
+
+	ctx->plugins = xmalloc0(sizeof(struct plugin) * (ctx->n_plugins + 1));
+
+	b = strdup(plugins);
+	if (b == NULL) {
+		pexit("Failed to strdup");
+		return -1;
+	}
+	for (s = 0, it = strtok_r(b, ":", &saveptr); it; s++, it = strtok_r(NULL, ":", &saveptr)) {
+		run_oci_seccomp_notify_plugin_version_cb version_cb;
+		run_oci_seccomp_notify_start_cb start_cb;
+		void *opq = NULL;
+
+		ctx->plugins[s].handle = dlopen(it, RTLD_NOW);
+		if (ctx->plugins[s].handle == NULL) {
+			pexitf("cannot load `%s`: %s", it, dlerror());
+			return -1;
+		}
+
+		version_cb = (run_oci_seccomp_notify_plugin_version_cb)dlsym(ctx->plugins[s].handle, "run_oci_seccomp_notify_version");
+		if (version_cb != NULL) {
+			int version;
+
+			version = version_cb();
+			if (version != 1) {
+				pexitf("invalid version supported by the plugin `%s`", it);
+				return -1;
+			}
+		}
+
+		ctx->plugins[s].handle_request_cb =
+			(run_oci_seccomp_notify_handle_request_cb)dlsym(ctx->plugins[s].handle, "run_oci_seccomp_notify_handle_request");
+		if (ctx->plugins[s].handle_request_cb == NULL) {
+			pexitf("plugin `%s` doesn't export `run_oci_seccomp_notify_handle_request`", it);
+			return -1;
+		}
+
+		start_cb = (run_oci_seccomp_notify_start_cb)dlsym(ctx->plugins[s].handle, "run_oci_seccomp_notify_start");
+		if (start_cb) {
+			int ret;
+
+			ret = start_cb(&opq, conf, sizeof(*conf));
+			if (ret != 0) {
+				pexitf("error loading `%s`", it);
+				return -1;
+			}
+		}
+		ctx->plugins[s].opaque = opq;
+	}
+
+	/* Change ownership.  */
+	*out = ctx;
+	ctx = NULL;
+	return 0;
+}
+
+int seccomp_notify_plugins_event(struct seccomp_notify_context_s *ctx, int seccomp_fd)
+{
+	size_t i;
+	int ret;
+	bool handled = false;
+
+	memset(ctx->sreq, 0, ctx->sizes.seccomp_notif);
+	memset(ctx->sresp, 0, ctx->sizes.seccomp_notif_resp);
+
+	ret = ioctl(seccomp_fd, SECCOMP_IOCTL_NOTIF_RECV, ctx->sreq);
+	if (ret < 0) {
+		if (errno == ENOENT)
+			return 0;
+		nwarnf("Failed to read notification from %d", seccomp_fd);
+		return -1;
+	}
+
+	for (i = 0; i < ctx->n_plugins; i++) {
+		if (ctx->plugins[i].handle_request_cb) {
+			int resp_handled = 0;
+			int ret;
+
+			ret = ctx->plugins[i].handle_request_cb(ctx->plugins[i].opaque, &ctx->sizes, ctx->sreq, ctx->sresp, seccomp_fd,
+								&resp_handled);
+			if (ret != 0) {
+				nwarnf("Failed to handle seccomp notification from fd %d", seccomp_fd);
+				return -1;
+			}
+
+			switch (resp_handled) {
+			case RUN_OCI_SECCOMP_NOTIFY_HANDLE_NOT_HANDLED:
+				break;
+
+			case RUN_OCI_SECCOMP_NOTIFY_HANDLE_SEND_RESPONSE:
+				handled = true;
+				break;
+
+			/* The plugin will take care of it.  */
+			case RUN_OCI_SECCOMP_NOTIFY_HANDLE_DELAYED_RESPONSE:
+				return 0;
+
+			case RUN_OCI_SECCOMP_NOTIFY_HANDLE_SEND_RESPONSE_AND_CONTINUE:
+				ctx->sresp->flags |= SECCOMP_USER_NOTIF_FLAG_CONTINUE;
+				handled = true;
+				break;
+
+			default:
+				pexitf("Unknown handler action specified %d", handled);
+				return -1;
+			}
+		}
+	}
+
+	/* No plugin could handle the request.  */
+	if (!handled) {
+		ctx->sresp->error = -ENOTSUP;
+		ctx->sresp->flags = 0;
+	}
+
+	ctx->sresp->id = ctx->sreq->id;
+	ret = ioctl(seccomp_fd, SECCOMP_IOCTL_NOTIF_SEND, ctx->sresp);
+	if (ret < 0) {
+		if (errno == ENOENT)
+			return 0;
+		nwarnf("Failed to send seccomp notification on fd %d", seccomp_fd);
+		return -errno;
+	}
+	return 0;
+}
+
+int seccomp_notify_plugins_free(struct seccomp_notify_context_s *ctx)
+{
+	size_t i;
+
+	if (ctx == NULL) {
+		nwarnf("Invalid seccomp notification context");
+		return -1;
+	}
+
+	free(ctx->sreq);
+	free(ctx->sresp);
+
+	for (i = 0; i < ctx->n_plugins; i++) {
+		if (ctx->plugins && ctx->plugins[i].handle) {
+			run_oci_seccomp_notify_stop_cb cb;
+
+			cb = (run_oci_seccomp_notify_stop_cb)dlsym(ctx->plugins[i].handle, "run_oci_seccomp_notify_stop");
+			if (cb)
+				cb(ctx->plugins[i].opaque);
+			dlclose(ctx->plugins[i].handle);
+		}
+	}
+
+	free(ctx);
+
+	return 0;
+}
+
+#else
+int seccomp_notify_plugins_load(G_GNUC_UNUSED struct seccomp_notify_context_s **out, G_GNUC_UNUSED const char *plugins,
+				G_GNUC_UNUSED struct seccomp_notify_conf_s *conf)
+{
+	pexit("seccomp support not available");
+	return -1;
+}
+
+int seccomp_notify_plugins_event(G_GNUC_UNUSED struct seccomp_notify_context_s *ctx, G_GNUC_UNUSED int seccomp_fd)
+{
+	pexit("seccomp support not available");
+	return -1;
+}
+
+int seccomp_notify_plugins_free(G_GNUC_UNUSED struct seccomp_notify_context_s *ctx)
+{
+	pexit("seccomp support not available");
+	return -1;
+}
+#endif
+
+static void cleanup_seccomp_plugins()
+{
+	if (seccomp_notify_ctx) {
+		seccomp_notify_plugins_free(seccomp_notify_ctx);
+		seccomp_notify_ctx = NULL;
+	}
+}
+
+void cleanup_seccomp_notify_pluginsp(void *p)
+{
+	struct seccomp_notify_context_s **pp = p;
+	if (*pp) {
+		seccomp_notify_plugins_free(*pp);
+		*pp = NULL;
+	}
+}
+
+static inline void *xmalloc0(size_t size)
+{
+	void *res = calloc(1, size);
+	if (res == NULL)
+		pexitf("calloc");
+	return res;
+}
+
+#if USE_SECCOMP
+static int seccomp_syscall(unsigned int op, unsigned int flags, void *args)
+{
+	errno = 0;
+	return syscall(__NR_seccomp, op, flags, args);
+}
+#endif

--- a/src/seccomp_notify.h
+++ b/src/seccomp_notify.h
@@ -1,0 +1,18 @@
+#ifndef SECCOMP_NOTIFY_H
+#define SECCOMP_NOTIFY_H
+
+#include "seccomp_notify_plugin.h"
+
+struct seccomp_notify_context_s;
+
+gboolean seccomp_cb(int fd, GIOCondition condition, G_GNUC_UNUSED gpointer user_data);
+gboolean seccomp_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC_UNUSED gpointer user_data);
+
+int seccomp_notify_plugins_load(struct seccomp_notify_context_s **out, const char *plugins, struct seccomp_notify_conf_s *conf);
+int seccomp_notify_plugins_event(struct seccomp_notify_context_s *ctx, int seccomp_fd);
+int seccomp_notify_plugins_free(struct seccomp_notify_context_s *ctx);
+
+#define cleanup_seccomp_notify_context __attribute__((cleanup(cleanup_seccomp_notify_pluginsp)))
+void cleanup_seccomp_notify_pluginsp(void *p);
+
+#endif

--- a/src/seccomp_notify_plugin.h
+++ b/src/seccomp_notify_plugin.h
@@ -1,0 +1,40 @@
+#ifndef SECCOMP_NOTIFY_PLUGINPLUGIN_H
+
+#include <linux/seccomp.h>
+
+struct seccomp_notify_conf_s {
+	const char *runtime_root_path;
+	const char *name;
+	const char *bundle_path;
+	const char *oci_config_path;
+};
+
+/* The plugin doesn't know how to handle the request.  */
+#define RUN_OCI_SECCOMP_NOTIFY_HANDLE_NOT_HANDLED 0
+/* The plugin filled the response and it is ready to write.  */
+#define RUN_OCI_SECCOMP_NOTIFY_HANDLE_SEND_RESPONSE 1
+/* The plugin will handle the request and write directly to the fd.  */
+#define RUN_OCI_SECCOMP_NOTIFY_HANDLE_DELAYED_RESPONSE 2
+/* Specify SECCOMP_USER_NOTIF_FLAG_CONTINUE in the flags.  */
+#define RUN_OCI_SECCOMP_NOTIFY_HANDLE_SEND_RESPONSE_AND_CONTINUE 3
+
+/* Configure the plugin.  Return an opaque pointer that will be used for successive calls.  */
+typedef int (*run_oci_seccomp_notify_start_cb)(void **opaque, struct seccomp_notify_conf_s *conf, size_t size_configuration);
+
+/* Try to handle a single request.  It MUST be defined.
+   HANDLED specifies how the request was handled by the plugin:
+   0: not handled, try next plugin or return ENOTSUP if it is the last plugin.
+   RUN_OCI_SECCOMP_NOTIFY_HANDLE_SEND_RESPONSE: sresp filled and ready to be notified to seccomp.
+   RUN_OCI_SECCOMP_NOTIFY_HANDLE_DELAYED_RESPONSE: the notification will be handled internally by the plugin and forwarded to seccomp_fd. It
+   is useful for asynchronous handling.
+*/
+typedef int (*run_oci_seccomp_notify_handle_request_cb)(void *opaque, struct seccomp_notif_sizes *sizes, struct seccomp_notif *sreq,
+							struct seccomp_notif_resp *sresp, int seccomp_fd, int *handled);
+
+/* Stop the plugin.  The opaque value is the return value from run_oci_seccomp_notify_start.  */
+typedef int (*run_oci_seccomp_notify_stop_cb)(void *opaque);
+
+/* Retrieve the API version used by the plugin.  It MUST return 1. */
+typedef int (*run_oci_seccomp_notify_plugin_version_cb)();
+
+#endif


### PR DESCRIPTION
add support for seccomp notify and add a basic support for emulating
mknod and mknodat.  The handler implementation is likely going to
change, for now it is just a PoC to show how it would work.

Requires: https://github.com/containers/crun/pull/438
Requires: libseccomp-2.5

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>