### PR TITLE
Fix nix build for failing e2fsprogs tests

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -38,6 +38,11 @@ let
             sed -ri "s;$out/(.*);$nukedRef/\1;g" $lib/lib/libsystemd.a
           '';
         });
+        e2fsprogs = pkg.e2fsprogs.overrideAttrs(x: {
+          postPatch = x.postPatch + ''
+            rm -rf tests/d_fallocate*
+          '';
+        });
       };
     };
   });


### PR DESCRIPTION
This removes additional tests from e2fsprogs which fail on some local
machines.

Closes #192 

@haircommander PTAL if this fixes the build issue on your machine.