### PR TITLE
Fail if conmon config could not be written

### DIFF
--- a/cmd/conmon-config/conmon-config.go
+++ b/cmd/conmon-config/conmon-config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 
 	"github.com/containers/conmon/runner/config"
 )
@@ -32,6 +33,6 @@ func main() {
 		config.ReopenLogsEvent,
 		config.TimedOutMessage)),
 		0644); err != nil {
-		fmt.Errorf(err.Error())
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
`fmt.Errorf` returns a result which has not being used in
conmon-config.go before this patch. We now `log.Fatal` the error to
actually report to the user that config generation has been failed.
