### PR TITLE
protect against kill(-1)

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -443,8 +443,9 @@ int main(int argc, char *argv[])
 	 */
 	if (timed_out && container_pid > 0) {
 		pid_t process_group = getpgid(container_pid);
-
-		if (process_group > 0)
+		/* if process_group is 1, we will end up calling
+		 *  kill(-1), which kills everything conmon is allowed to. */
+		if (process_group > 1)
 			kill(-process_group, SIGKILL);
 		else
 			kill(container_pid, SIGKILL);


### PR DESCRIPTION
if kill is passed a process that is less than -1, it kills every pid in the process group.
However, if it is passed -1, then conmon attempts to kill everything it can

protect against the case that getpgid returns a 1

Signed-off-by: Peter Hunt <pehunt@redhat.com>