### PR TITLE
Update nix pin with `make nixpkgs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ endif
 # Update nix/nixpkgs.json its latest stable commit
 .PHONY: nixpkgs
 nixpkgs:
-	@nix run -f channel:nixos-20.03 nix-prefetch-git -c nix-prefetch-git \
+	@nix run -f channel:nixos-20.09 nix-prefetch-git -c nix-prefetch-git \
 		--no-deepClone https://github.com/nixos/nixpkgs > nix/nixpkgs.json
 
 # Build statically linked binary

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -59,10 +59,10 @@ let
     doCheck = false;
     enableParallelBuilding = true;
     outputs = [ "out" ];
-    nativeBuildInputs = [ bash git pcre pkg-config which ];
+    nativeBuildInputs = [ bash gitMinimal pcre pkg-config which ];
     buildInputs = [ glibc glibc.static glib ];
     prePatch = ''
-      export CFLAGS='-static'
+      export CFLAGS='-static -pthread'
       export LDFLAGS='-s -w -static-libgcc -static'
       export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
     '';

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,10 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "6e089d30148953df7abb3a1167169afc7848499c",
-  "date": "2020-11-05T09:56:30+01:00",
-  "sha256": "0ydqjkz7payl16psx445jwh6dc6lgbvj2w11xin1dqvbpcp03jcy",
-  "fetchSubmodules": false
+  "rev": "6ea2fd15d881006b41ea5bbed0f76bffcd85f9f9",
+  "date": "2020-12-20T13:26:58+10:00",
+  "path": "/nix/store/kyw1ackbp9qh1jzlzwmjvi5i3541ym5z-nixpkgs",
+  "sha256": "0kgqmw4ki10b37530jh912sn49x3gay5cnmfr8yz2yp8nvkrk236",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
 }


### PR DESCRIPTION
Regular monthly update; BTW, it is now failing as below:

```
$ nix build -f nix/
builder for '/nix/store/g42612r1iswgm8fdbxda7qhssj011nzs-gts-0.7.6.drv' failed with exit code 2; last 10 log lines:
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../src/.libs/libgts.so: undefined reference to `pthread_create'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../src/.libs/libgts.so: undefined reference to `pthread_mutexattr_init'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../src/.libs/libgts.so: undefined reference to `pthread_mutexattr_destroy'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../src/.libs/libgts.so: undefined reference to `pthread_rwlock_tryrdlock'
  collect2: error: ld returned 1 exit status
  make[2]: *** [Makefile:467: gts2oogl] Error 1
  make[2]: Leaving directory '/tmp/nix-build-gts-0.7.6.drv-1/gts-0.7.6/tools'
  make[1]: *** [Makefile:475: all-recursive] Error 1
  make[1]: Leaving directory '/tmp/nix-build-gts-0.7.6.drv-1/gts-0.7.6'
  make: *** [Makefile:382: all] Error 2
cannot build derivation '/nix/store/yx7j53xypxwskjlh9ff6d95ydvjdzpra-graphviz-2.42.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/wnin9i1lfyis8hj16fq8c9p4in3krh7a-wayland-1.18.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/dy2xmvmlh16mi8ibnhgkd6zq94v63mk3-mesa-20.2.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/7210srg79xyxjbdq1hiskj7cqkdwii8r-libGL-1.3.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/i2646hq9w347lqxpdw4rjv9vifmnhwpg-cairo-1.16.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/khx8whp237bzw2wi0lwnl6kfy3pisrvb-ruby2.6.6-mathematical-1.6.12.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/595687dkb6f3wix05s1h8jc6841fgnvw-asciidoctor-2.0.10.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/cadd4djn3qa4d9mbxl0zg4q5p8va9s61-asciidoctor-2.0.10.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/gybkd2xjw17cy1kh0y36m0kaasg1gwqb-git-2.29.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/3cnmzw2q9r0wbr5gcabk55kcaf26s3ha-conmon.drv': 1 dependencies couldn't be built
[0 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/3cnmzw2q9r0wbr5gcabk55kcaf26s3ha-conmon.drv' failed
```