### PR TITLE
conn_sock: fix path opening

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -98,7 +98,8 @@ GOptionEntry opt_entries[] = {
 	{"terminal", 't', 0, G_OPTION_ARG_NONE, &opt_terminal, "Allocate a pseudo-TTY. The default is false", NULL},
 	{"timeout", 'T', 0, G_OPTION_ARG_INT, &opt_timeout, "Kill container after specified timeout in seconds.", NULL},
 	{"version", 0, 0, G_OPTION_ARG_NONE, &opt_version, "Print the version and exit", NULL},
-	{"full-attach", 0, 0, G_OPTION_ARG_NONE, &opt_full_attach_path, "Don't truncate the path to the attach socket.", NULL},
+	{"full-attach", 0, 0, G_OPTION_ARG_NONE, &opt_full_attach_path,
+	 "Don't truncate the path to the attach socket. This option causes conmon to ignore --socket-dir-path", NULL},
 	{NULL, 0, 0, 0, NULL, NULL, NULL}};
 
 


### PR DESCRIPTION
I must admit I didn't test correctly, and there were two regressions with the previous commit on conn_sock.
1: sock_fullpath doesn't exist at the time that we need to copy its location into sun_path. As such, we need to use the proc entry of the parent dir, and use that as the parent path.
2: we do need the symlink to the bundle_path, as that's where the attach file actually lives.

Signed-off-by: Peter Hunt <pehunt@redhat.com>