### PR TITLE
Add arm64 static build binary

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -141,28 +141,44 @@ static_binary_task:
         memory: 12
         disk: 200
 
-    init_script: |
-        set -ex
-        setenforce 0
-        growpart /dev/sda 1 || true
-        resize2fs /dev/sda1 || true
-        yum -y install podman
+    # Community-maintained task, may fail on occasion.  If so, uncomment
+    # the next line and file an issue with details about the failure.
+    # allow_failures: true
 
-    nix_cache:
-      folder: '.cache'
-      fingerprint_script: |
-        echo "nix-v1-$(sha1sum nix/nixpkgs.json | head -c 40)"
+    timeout_in: '20m'
+
+    env:
+        # Do not use 'latest', fixed-version tag for runtime stability.
+        CTR_FQIN: "docker.io/nixos/nix:2.3.6"
+        # Authentication token for pushing the build cache to cachix.
+        # This is critical, it helps to avoid a very lengthy process of
+        # statically building every dependency needed to build conmon.
+        # Assuming the pinned nix dependencies in nix/nixpkgs.json have not
+        # changed, this cache will ensure that only the static conmon binary is
+        # built.
+        CACHIX_AUTH_TOKEN: ENCRYPTED[4c3b8d82b0333abf048c56a71f2559ddb1c9ed38f0c28916eca13f79affa5904cf90c76a5bd8686680c89f41079ef341]
+
+    alias: static_binary
+
+    matrix:
+      - env:
+            TARGET: default.nix
+      - env:
+            TARGET: default-arm64.nix
 
     build_script: |
         set -ex
-        mkdir -p .cache
-        mv .cache /nix
-        if [[ -z $(ls -A /nix) ]]; then podman run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
-        podman run --rm --privileged -ti -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
+        podman run -i --rm \
+          -e CACHIX_AUTH_TOKEN \
+          -v $PWD:$PWD:Z \
+          -w $PWD \
+          $CTR_FQIN \
+          sh -c \
+          "nix-env -iA cachix -f https://cachix.org/api/v1/install && \
+           cachix use conmon && \
+           nix-build nix/$TARGET && \
+           nix-store -qR --include-outputs \$(nix-instantiate nix/$TARGET) | grep -v conmon | cachix push conmon && \
+           cp -R result/bin ."
 
     binaries_artifacts:
-        path: "result/bin/conmon"
-
-    save_cache_script: |
-        mv /nix .cache
-        chown -Rf $(whoami) .cache
+        path: "bin/conmon"

--- a/nix/default-arm64.nix
+++ b/nix/default-arm64.nix
@@ -1,0 +1,95 @@
+let
+  pkgs = (import ./nixpkgs.nix {
+    crossSystem = {
+      config = "aarch64-unknown-linux-gnu";
+    };
+    overlays = [
+      (final: pkg: {
+        pcre = (static pkg.pcre).overrideAttrs (x: {
+          configureFlags = x.configureFlags ++ [
+            "--enable-static"
+          ];
+        });
+      })
+    ];
+    config = {
+      packageOverrides = pkg: {
+        autogen = (static pkg.autogen);
+        e2fsprogs = (static pkg.e2fsprogs);
+        libuv = (static pkg.libuv);
+        glib = (static pkg.glib).overrideAttrs (x: {
+          outputs = [ "bin" "out" "dev" ];
+          mesonFlags = [
+            "-Ddefault_library=static"
+            "-Ddevbindir=${placeholder ''dev''}/bin"
+            "-Dgtk_doc=false"
+            "-Dnls=disabled"
+          ];
+          postInstall = ''
+            moveToOutput "share/glib-2.0" "$dev"
+            substituteInPlace "$dev/bin/gdbus-codegen" --replace "$out" "$dev"
+            sed -i "$dev/bin/glib-gettextize" -e "s|^gettext_dir=.*|gettext_dir=$dev/share/glib-2.0/gettext|"
+            sed '1i#line 1 "${x.pname}-${x.version}/include/glib-2.0/gobject/gobjectnotifyqueue.c"' \
+              -i "$dev"/include/glib-2.0/gobject/gobjectnotifyqueue.c
+          '';
+        });
+        gnutls = (static pkg.gnutls).overrideAttrs (x: {
+          configureFlags = (x.configureFlags or [ ]) ++ [
+            "--disable-non-suiteb-curves"
+            "--disable-openssl-compatibility"
+            "--disable-rpath"
+            "--enable-local-libopts"
+            "--without-p11-kit"
+          ];
+        });
+        systemd = (static pkg.systemd).overrideAttrs (x: {
+          outputs = [ "out" "dev" ];
+          mesonFlags = x.mesonFlags ++ [
+            "-Dstatic-libsystemd=true"
+          ];
+        });
+      };
+    };
+  });
+
+  static = pkg: pkg.overrideAttrs (x: {
+    doCheck = false;
+    configureFlags = (x.configureFlags or [ ]) ++ [
+      "--without-shared"
+      "--disable-shared"
+    ];
+    dontDisableStatic = true;
+    enableSharedExecutables = false;
+    enableStatic = true;
+  });
+
+  self = with pkgs; stdenv.mkDerivation rec {
+    name = "conmon";
+    src = ./..;
+    vendorSha256 = null;
+    doCheck = false;
+    enableParallelBuilding = true;
+    outputs = [ "out" ];
+    nativeBuildInputs = with buildPackages; [
+      bash
+      gitMinimal
+      pcre
+      pkg-config
+      which
+    ];
+    buildInputs = [ glibc glibc.static glib ];
+    prePatch = ''
+      export CFLAGS='-static -pthread'
+      export LDFLAGS='-s -w -static-libgcc -static'
+      export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
+    '';
+    buildPhase = ''
+      patchShebangs .
+      make
+    '';
+    installPhase = ''
+      install -Dm755 bin/conmon $out/bin/conmon
+    '';
+  };
+in
+self


### PR DESCRIPTION
This adds an arm64 derivation to the static binary build.

#### Manual test
```
> nix-build nix/arm64.nix
> file result/bin/conmon
result/bin/conmon: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, for GNU/Linux 2.6.32, stripped
```
Test build: [conmon.tar.gz](https://github.com/containers/conmon/files/5951723/conmon.tar.gz)
Refers to https://github.com/cri-o/cri-o/pull/4552