### PR TITLE
Add Podman integration test GitHub action

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,6 @@ on:
       - v*
     branches:
       - master
-      - ghactions # TODO: remove when it works
   pull_request:
 jobs:
   cri-o:
@@ -20,8 +19,8 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-integration-
+          key: go-integration-cri-o-${{ hashFiles('**/go.mod') }}
+          restore-keys: go-integration-cri-o-
       - run: hack/github-actions-setup
       - run: sudo make install
       - name: Run CRI-O integration tests
@@ -31,3 +30,50 @@ jobs:
           sudo -E test/test_runner.sh
         env:
           JOBS: '2'
+
+  podman:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-integration-podman-${{ hashFiles('**/go.mod') }}
+          restore-keys: go-integration-podman-
+      - run: hack/github-actions-setup
+      - name: Run Podman integration tests
+        run: |
+          git clone https://github.com/containers/podman
+          cd podman
+          make bin/podman
+          sudo -E ginkgo \
+            -skip 'run.apparmor.disabled|image.trust.show.--json|run.network.bind.to.HostIP' \
+            -noColor \
+            -v test/e2e/.
+
+  podman-system:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-integration-podman-${{ hashFiles('**/go.mod') }}
+          restore-keys: go-integration-podman-
+      - run: hack/github-actions-setup
+      - name: Run Podman system tests
+        run: |
+          git clone https://github.com/containers/podman
+          cd podman
+          make bin/podman
+          sudo -E make localsystem

--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -40,6 +40,7 @@ install_packages() {
         conntrack \
         libaio-dev \
         libapparmor-dev \
+        libbtrfs-dev \
         libcap-dev \
         libdevmapper-dev \
         libfuse-dev \


### PR DESCRIPTION
We now add the Podman integration tests side-by-side to the CRI-O run.
This way we can ensure that changes to conmon will not negatively impact
Podman.

Some tests have to be ecluded for now, we have to dig deeper to find out
why they do not run.
