### PR TITLE
Add Kubernetes e2e tests as GitHub action

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,23 @@ on:
       - master
   pull_request:
 jobs:
+  kubernetes-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-integration-kubernetes-e2e-${{ hashFiles('**/go.mod') }}
+          restore-keys: go-integration-kubernetes-e2e-
+      - run: hack/github-actions-setup
+      - run: sudo hack/kubernetes-e2e
+
   conmon:
     runs-on: ubuntu-latest
     steps:
@@ -24,12 +41,9 @@ jobs:
       - run: hack/github-actions-setup
       - name: Run conmon integration tests
         run: |
-          make
-          sudo make install PREFIX=/usr # currently, the conmon location is hardcoded to /usr/bin/conmon
           make vendor
           sudo make test
-        env:
-          JOBS: '2'
+
   cri-o:
     runs-on: ubuntu-latest
     steps:
@@ -45,7 +59,6 @@ jobs:
           key: go-integration-cri-o-${{ hashFiles('**/go.mod') }}
           restore-keys: go-integration-cri-o-
       - run: hack/github-actions-setup
-      - run: sudo make install
       - name: Run CRI-O integration tests
         run: |
           cd cri-o

--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -12,6 +12,7 @@ main() {
     prepare_system
 
     install_packages
+    install_conmon
     install_bats
     install_critools
     install_runc
@@ -34,6 +35,12 @@ prepare_system() {
     sudo iptables -t nat -I POSTROUTING -s 127.0.0.0/8 ! -d 127.0.0.0/8 -j MASQUERADE
 }
 
+remove_packages() {
+    sudo apt-get remove \
+        conmon \
+        containernetworking-plugins
+}
+
 install_packages() {
     sudo apt update
     sudo apt install -y \
@@ -54,6 +61,11 @@ install_packages() {
         libudev-dev \
         socat \
         uuid-dev
+}
+
+install_conmon() {
+    sudo make install
+    conmon --version
 }
 
 install_bats() {

--- a/hack/kubernetes-e2e
+++ b/hack/kubernetes-e2e
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check for root
+if [[ $EUID -ne 0 ]]; then
+    echo "Please run this script as root"
+    exit 1
+fi
+
+# Install latest CRI-O
+curl https://raw.githubusercontent.com/cri-o/cri-o/master/scripts/get | bash
+crio --version
+
+# Use runc as default runtime
+rm /etc/crio/crio.conf.d/10-crun.conf
+cat <<EOT >>/etc/crio/crio.conf.d/10-config.conf
+[crio.runtime]
+log_level = "debug"
+[crio.runtime.runtimes.runc]
+runtime_path = "/usr/local/bin/runc"
+EOT
+runc --version
+
+# Start CRI-O
+systemctl daemon-reload
+systemctl start crio
+systemctl is-active --quiet crio && echo CRI-O is running
+journalctl --no-pager -u crio
+
+# Start Kubernetes
+GOROOT="$GOROOT_1_16_X64"
+GOPATH="$HOME/go"
+PATH="$GOROOT/bin:$PATH"
+K8SPATH="$GOPATH/src/k8s.io"
+mkdir -p "$K8SPATH"
+pushd "$K8SPATH"
+git clone --depth=1 https://github.com/kubernetes/kubernetes
+pushd kubernetes
+
+LATEST=$(curl -sSfL https://dl.k8s.io/ci/latest.txt)
+echo "Using Kubernetes build $LATEST"
+
+URL="https://dl.k8s.io/ci/$LATEST"
+mkdir -p _output/bin
+
+echo Downloading server binaries
+curl -sSfL "$URL/kubernetes-server-linux-amd64.tar.gz" -o- | tar xfz -
+cp kubernetes/server/bin/{kubectl,kube-apiserver,kube-controller-manager,kube-proxy,kube-scheduler,kubelet} \
+    _output/bin
+
+echo Downloading test binaries
+curl -sSfL "$URL/kubernetes-test-linux-amd64.tar.gz" -o- | tar xfz -
+cp kubernetes/test/bin/{ginkgo,e2e.test} _output/bin
+
+export CONTAINER_RUNTIME=remote
+export CGROUP_DRIVER=systemd
+export CGROUP_ROOT=/
+export KUBELET_FLAGS='--runtime-cgroups=/system.slice/crio.service --non-masquerade-cidr=0.0.0.0/0'
+export CONTAINER_RUNTIME_ENDPOINT=/var/run/crio/crio.sock
+export ALLOW_PRIVILEGED=1
+
+IP=$(ip route get 1.2.3.4 | cut -d ' ' -f7 | tr -d '[:space:]')
+echo "Using IP: $IP"
+export DNS_SERVER_IP=$IP
+export API_HOST_IP=$IP
+
+iptables -F
+hack/install-etcd.sh
+export PATH="$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$PATH"
+
+OUTPUT=$(mktemp)
+hack/local-up-cluster.sh -O 2>&1 | tee "$OUTPUT" &
+PID=$!
+
+until grep -q "Local Kubernetes cluster is running" "$OUTPUT"; do
+    echo Waiting for hack/local-up-cluster.sh
+    if ! ps $PID >/dev/null; then
+        exit 1
+    fi
+    sleep 5
+done
+
+echo Cluster is up and running
+
+# Run the tests
+export KUBERUN=/var/run/kubernetes
+export KUBECONFIG=$KUBERUN/admin.kubeconfig
+export PATH="$GOPATH/src/k8s.io/kubernetes/_output/local/bin/linux/amd64:$PATH"
+export KUBE_MASTER_URL=$IP
+export KUBE_MASTER_IP=$IP
+export KUBE_MASTER=$IP
+
+export GINKGO_PARALLEL_NODES=4
+export GINKGO_PARALLEL=y
+
+_output/bin/e2e.test --provider=local --host="https://$IP:6443" \
+    --ginkgo.focus='\[NodeConformance|NodeFeature:.*\]' \
+    --ginkgo.skip='\[Flaky|Slow|Serial|sig-network|NodeFeature:RuntimeHandler\]|exec hook properly'


### PR DESCRIPTION
This adds a GitHub actions test suite to run a subset of the node e2e
tests with the locally built version of conmon.
