### PR TITLE
call functions registered with atexit on SIGTERM

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -45,6 +45,8 @@ int main(int argc, char *argv[])
 
 	/* ignoring SIGPIPE prevents conmon from being spuriously killed */
 	signal(SIGPIPE, SIG_IGN);
+	/* Catch SIGTERM and call exit(). This causes the atexit functions to be called. */
+	signal(SIGTERM, handle_signal);
 
 	int start_pipe_fd = get_pipe_fd_from_env("_OCI_STARTPIPE");
 	if (start_pipe_fd > 0) {

--- a/src/ctr_exit.c
+++ b/src/ctr_exit.c
@@ -200,3 +200,8 @@ void reap_children()
 	while (waitpid(-1, NULL, WNOHANG) > 0)
 		;
 }
+
+void handle_signal(G_GNUC_UNUSED const int signum)
+{
+	exit(EXIT_FAILURE);
+}

--- a/src/ctr_exit.h
+++ b/src/ctr_exit.h
@@ -24,5 +24,6 @@ void runtime_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointer 
 void container_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointer user_data);
 void do_exit_command();
 void reap_children();
+void handle_signal(G_GNUC_UNUSED const int signum);
 
 #endif // CTR_EXIT_H


### PR DESCRIPTION
Shout out to https://stackoverflow.com/questions/40311937/terminating-a-program-with-calling-atexit-functions-linux for the elegant solution.

Signed-off-by: Peter Hunt <pehunt@redhat.com>