### PR TITLE
seccomp: fix for unsupported versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ else ifeq ($(shell $(PKG_CONFIG) --exists libsystemd && echo "0" || echo "1"), 0
 	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libsystemd) -D USE_JOURNALD=0
 endif
 
-ifeq ($(shell $(PKG_CONFIG) --exists libseccomp && echo "0" || echo "1"), 0)
+ifeq ($(shell $(PKG_CONFIG) --atleast-version 2.5.0 libseccomp && echo "0" || echo "1"), 0)
 	override LIBS += $(shell $(PKG_CONFIG) --libs libseccomp) -ldl
 	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libseccomp) -D USE_SECCOMP=1
 else

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -180,10 +180,11 @@ int main(int argc, char *argv[])
 	if (opt_seccomp_notify_socket != NULL) {
 #if !USE_SECCOMP
 		pexit("seccomp support not present");
-#endif
+#else
 		if (opt_seccomp_notify_plugins == NULL)
 			pexit("seccomp notify socket specified without any plugin");
 		seccomp_listener = setup_seccomp_socket(opt_seccomp_notify_socket);
+#endif
 	}
 
 	/* We always create a stderr pipe, because that way we can capture

--- a/src/seccomp_notify.h
+++ b/src/seccomp_notify.h
@@ -3,10 +3,11 @@
 
 #include "seccomp_notify_plugin.h"
 
+#if USE_SECCOMP
+
 struct seccomp_notify_context_s;
 
 gboolean seccomp_cb(int fd, GIOCondition condition, G_GNUC_UNUSED gpointer user_data);
-gboolean seccomp_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC_UNUSED gpointer user_data);
 
 int seccomp_notify_plugins_load(struct seccomp_notify_context_s **out, const char *plugins, struct seccomp_notify_conf_s *conf);
 int seccomp_notify_plugins_event(struct seccomp_notify_context_s *ctx, int seccomp_fd);
@@ -15,4 +16,6 @@ int seccomp_notify_plugins_free(struct seccomp_notify_context_s *ctx);
 #define cleanup_seccomp_notify_context __attribute__((cleanup(cleanup_seccomp_notify_pluginsp)))
 void cleanup_seccomp_notify_pluginsp(void *p);
 
-#endif
+#endif // USE_SECCOMP
+gboolean seccomp_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC_UNUSED gpointer user_data);
+#endif // SECCOMP_NOTIFY_H

--- a/src/seccomp_notify_plugin.h
+++ b/src/seccomp_notify_plugin.h
@@ -1,6 +1,8 @@
-#ifndef SECCOMP_NOTIFY_PLUGINPLUGIN_H
+#ifndef SECCOMP_NOTIFY_PLUGIN_H
 
 #include <linux/seccomp.h>
+
+#if USE_SECCOMP
 
 struct seccomp_notify_conf_s {
 	const char *runtime_root_path;
@@ -37,4 +39,5 @@ typedef int (*run_oci_seccomp_notify_stop_cb)(void *opaque);
 /* Retrieve the API version used by the plugin.  It MUST return 1. */
 typedef int (*run_oci_seccomp_notify_plugin_version_cb)();
 
-#endif
+#endif // USE_SECCOMP
+#endif // SECCOMP_NOTIFY_PLUGIN_H


### PR DESCRIPTION
if seccomp version is lower than 2.5.0, then we should not compile any seccomp related things
and fail if users attempt to specify them

Signed-off-by: Peter Hunt <pehunt@redhat.com>