### PR TITLE
Makefile: fix seccomp notify compilation issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ override CFLAGS += $(shell $(PKG_CONFIG) --cflags glib-2.0) -DVERSION=\"$(VERSIO
 # and allow the compilation to complete.
 ifeq ($(shell $(PKG_CONFIG) --exists libsystemd-journal && echo "0"), 0)
 	override LIBS += $(shell $(PKG_CONFIG) --libs libsystemd-journal)
-	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libsystemd-journal) -D USE_JOURNALD=0
+	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libsystemd-journal) -D USE_JOURNALD=1
 else ifeq ($(shell $(PKG_CONFIG) --exists libsystemd && echo "0"), 0)
 	override LIBS += $(shell $(PKG_CONFIG) --libs libsystemd)
-	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libsystemd) -D USE_JOURNALD=0
+	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libsystemd) -D USE_JOURNALD=1
 endif
 
 ifeq ($(shell $(PKG_CONFIG) --atleast-version 2.5.0 libseccomp && echo "0"), 0)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 all: git-vars bin bin/conmon
 
 git-vars:
-ifeq ($(shell bash -c '[[ `command -v git` && `git rev-parse --git-dir 2>/dev/null` ]] && echo true'),true)
+ifeq ($(shell bash -c '[[ `command -v git` && `git rev-parse --git-dir 2>/dev/null` ]] && echo 0'),0)
 	$(eval COMMIT_NO :=$(shell git rev-parse HEAD 2> /dev/null || true))
 	$(eval GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}"))
 	$(eval GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))
@@ -38,15 +38,15 @@ override CFLAGS += $(shell $(PKG_CONFIG) --cflags glib-2.0) -DVERSION=\"$(VERSIO
 # "pkg-config --exists" will error if the package doesn't exist. Make can only compare
 # output of commands, so the echo commands are to allow pkg-config to error out, make to catch it,
 # and allow the compilation to complete.
-ifeq ($(shell $(PKG_CONFIG) --exists libsystemd-journal && echo "0" || echo "1"), 0)
+ifeq ($(shell $(PKG_CONFIG) --exists libsystemd-journal && echo "0"), 0)
 	override LIBS += $(shell $(PKG_CONFIG) --libs libsystemd-journal)
 	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libsystemd-journal) -D USE_JOURNALD=0
-else ifeq ($(shell $(PKG_CONFIG) --exists libsystemd && echo "0" || echo "1"), 0)
+else ifeq ($(shell $(PKG_CONFIG) --exists libsystemd && echo "0"), 0)
 	override LIBS += $(shell $(PKG_CONFIG) --libs libsystemd)
 	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libsystemd) -D USE_JOURNALD=0
 endif
 
-ifeq ($(shell $(PKG_CONFIG) --atleast-version 2.5.0 libseccomp && echo "0" || echo "1"), 0)
+ifeq ($(shell $(PKG_CONFIG) --atleast-version 2.5.0 libseccomp && echo "0"), 0)
 	override LIBS += $(shell $(PKG_CONFIG) --libs libseccomp) -ldl
 	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libseccomp) -D USE_SECCOMP=1
 else

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,6 @@ endif
 ifeq ($(shell hack/seccomp-notify.sh), 0)
 	override LIBS += $(shell $(PKG_CONFIG) --libs libseccomp) -ldl
 	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libseccomp) -D USE_SECCOMP=1
-else
-	override CFLAGS += -D USE_SECCOMP=0
 endif
 
 # Update nix/nixpkgs.json its latest stable commit

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ else ifeq ($(shell $(PKG_CONFIG) --exists libsystemd && echo "0"), 0)
 	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libsystemd) -D USE_JOURNALD=1
 endif
 
-ifeq ($(shell $(PKG_CONFIG) --atleast-version 2.5.0 libseccomp && echo "0"), 0)
+ifeq ($(shell hack/seccomp-notify.sh), 0)
 	override LIBS += $(shell $(PKG_CONFIG) --libs libseccomp) -ldl
 	override CFLAGS += $(shell $(PKG_CONFIG) --cflags libseccomp) -D USE_SECCOMP=1
 else

--- a/hack/seccomp-notify.sh
+++ b/hack/seccomp-notify.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if $(printf '#include <linux/seccomp.h>\nvoid main(){struct seccomp_notif_sizes s;}' | cc -x c - -o /dev/null 2> /dev/null && pkg-config --atleast-version 2.5.0 libseccomp); then
+        echo "0"
+fi

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (opt_seccomp_notify_socket != NULL) {
-#if !USE_SECCOMP
+#ifdef USE_SECCOMP
 		pexit("seccomp support not present");
 #else
 		if (opt_seccomp_notify_plugins == NULL)

--- a/src/seccomp_notify.c
+++ b/src/seccomp_notify.c
@@ -21,7 +21,7 @@
 #include "cmsg.h"
 #include "seccomp_notify.h"
 
-#if USE_SECCOMP
+#ifdef USE_SECCOMP
 
 #ifndef SECCOMP_USER_NOTIF_FLAG_CONTINUE
 #define SECCOMP_USER_NOTIF_FLAG_CONTINUE (1UL << 0)

--- a/src/seccomp_notify.h
+++ b/src/seccomp_notify.h
@@ -3,7 +3,7 @@
 
 #include "seccomp_notify_plugin.h"
 
-#if USE_SECCOMP
+#ifdef USE_SECCOMP
 
 struct seccomp_notify_context_s;
 

--- a/src/seccomp_notify_plugin.h
+++ b/src/seccomp_notify_plugin.h
@@ -2,7 +2,7 @@
 
 #include <linux/seccomp.h>
 
-#if USE_SECCOMP
+#ifdef USE_SECCOMP
 
 struct seccomp_notify_conf_s {
 	const char *runtime_root_path;


### PR DESCRIPTION
on older kernels we need to also check if the proper headers are installed, in addition to the seccomp version

also, unify the syntax of conditional compilation variables 