### PR TITLE
Add libseccomp to build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ sudo yum install -y \
   git \
   glib2-devel \
   glibc-devel \
+  libseccomp-devel \
   make \
   pkgconfig \
   runc
@@ -59,6 +60,7 @@ sudo apt-get install \
   git \
   libc6-dev \
   libglib2.0-dev \
+  libseccomp-dev \
   pkg-config \
   make \
   runc


### PR DESCRIPTION
Fixes https://github.com/containers/conmon/issues/285

Seccomp is used in https://github.com/containers/conmon/blob/main/src/seccomp_notify.c#L9 but is not mentioned in the [dependencies](https://github.com/containers/conmon/blob/main/src/seccomp_notify.c#L9) section in README. 