### PR TITLE
Fix missing libseccomp dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ sudo yum install -y \
   git \
   glib2-devel \
   glibc-devel \
+  libseccomp-devel \
   make \
   pkgconfig \
   runc
@@ -59,6 +60,7 @@ sudo apt-get install \
   git \
   libc6-dev \
   libglib2.0-dev \
+  libseccomp-dev \
   pkg-config \
   make \
   runc


### PR DESCRIPTION
libseccomp dev librarty is missing for RPM and DEB based distros.

make fails with below error

> cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -DVERSION=\"2.0.30-dev\" -DGIT_COMMIT=\""018c40e0f7c66a08548745f458a64ee2508fb0b1-dirty"\"  -o src/seccomp
_notify.o -c src/seccomp_notify.c
src/seccomp_notify.c:9:10: fatal error: seccomp.h: No such file or directory
    9 | #include <seccomp.h>
      |          ^~~~~~~~~~~
compilation terminated.
make: *** [Makefile:71: src/seccomp_notify.o] Error 1