### PR TITLE
Allow WATCHDOG=1 through the proxied systemd notify socket

### DIFF
--- a/src/conn_sock.c
+++ b/src/conn_sock.c
@@ -374,6 +374,9 @@ static gboolean read_remote_sock(struct remote_sock_s *sock)
 		if (strstr(sock->buf, "READY=1")) {
 			strncpy(sock->buf, "READY=1", 8);
 			sock->remaining = 7;
+		} else if (strstr(sock->buf, "WATCHDOG=1")) {
+			strncpy(sock->buf, "WATCHDOG=1", 11);
+			sock->remaining = 10;
 		} else {
 			sock->remaining = 0;
 		}


### PR DESCRIPTION
`conmon` cannot be used to run systemd units using [`WatchdogSec=`](https://www.freedesktop.org/software/systemd/man/systemd.service.html#WatchdogSec=) because the _keep-alive ping_ is not passed along to the notify socket.

This PR adds `WATCHDOG=1` to the proxied states (in addition to `READY=1`).

What is the reason for only allowing the `READY=1` state through? Where is/should this limitation be documented?

[sd_notify](https://www.freedesktop.org/software/systemd/man/sd_notify.html#Description) supports significantly more states of which several could be used when running within a container. What would the preferred mode of handling more states be:
* extend the list of allowed states to include all the allowed ones? 
 * filter only specific states which may cause problems? `MAINPID=`? 
 * allow all states through unfiltered?