### PR TITLE
logging: new mode -l passthrough

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Run conmon integration tests
         run: |
           make vendor
-          sudo make test
+          sudo mkdir -p /var/run/crio
+          sudo make test-binary
 
   cri-o:
     runs-on: ubuntu-latest

--- a/runner/conmon/conmon.go
+++ b/runner/conmon/conmon.go
@@ -22,6 +22,7 @@ type ConmonInstance struct {
 	pidFile string
 	stdout  io.Writer
 	stderr  io.Writer
+	stdin   io.Reader
 
 	parentStartPipe  *os.File
 	parentAttachPipe *os.File
@@ -61,6 +62,7 @@ func NewConmonInstance(options ...ConmonOption) (*ConmonInstance, error) {
 
 	ci.cmd.Stdout = ci.stdout
 	ci.cmd.Stderr = ci.stderr
+	ci.cmd.Stdin = ci.stdin
 	return ci, nil
 }
 

--- a/runner/conmon/options.go
+++ b/runner/conmon/options.go
@@ -30,6 +30,13 @@ func WithStderr(stderr io.Writer) ConmonOption {
 	}
 }
 
+func WithStdin(stdin io.Reader) ConmonOption {
+	return func(ci *ConmonInstance) error {
+		ci.stdin = stdin
+		return nil
+	}
+}
+
 func WithPath(path string) ConmonOption {
 	return func(ci *ConmonInstance) error {
 		ci.path = path

--- a/runner/conmon_test/ctr_logs_test.go
+++ b/runner/conmon_test/ctr_logs_test.go
@@ -55,6 +55,11 @@ var _ = Describe("conmon ctr logs", func() {
 		_, err := os.Stat(tmpLogPath)
 		Expect(err).To(BeNil())
 	})
+	It("log driver as passthrough should pass", func() {
+		stdout, stderr := getConmonOutputGivenLogOpts(conmon.WithLogDriver("passthrough", ""))
+		Expect(stdout).To(BeEmpty())
+		Expect(stderr).To(BeEmpty())
+	})
 	It("log driver as k8s-file with invalid path should fail", func() {
 		_, stderr := getConmonOutputGivenLogOpts(conmon.WithLogDriver("k8s-file", invalidPath))
 		Expect(stderr).To(ContainSubstring("Failed to open log file"))

--- a/runner/conmon_test/suite_test.go
+++ b/runner/conmon_test/suite_test.go
@@ -37,8 +37,9 @@ func TestConmon(t *testing.T) {
 func getConmonOutputGivenOptions(options ...conmon.ConmonOption) (string, string) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	var stdin bytes.Buffer
 
-	options = append(options, conmon.WithStdout(&stdout), conmon.WithStderr(&stderr))
+	options = append(options, conmon.WithStdout(&stdout), conmon.WithStderr(&stderr), conmon.WithStdin(&stdin))
 
 	ci, err := conmon.CreateAndExecConmon(options...)
 	Expect(err).To(BeNil())

--- a/src/ctr_logging.h
+++ b/src/ctr_logging.h
@@ -9,5 +9,6 @@ void reopen_log_files(void);
 bool write_to_logs(stdpipe_t pipe, char *buf, ssize_t num_read);
 void configure_log_drivers(gchar **log_drivers, int64_t log_size_max_, char *cuuid_, char *name_, char *tag);
 void sync_logs(void);
+gboolean logging_is_passthrough(void);
 
 #endif /* !defined(CTR_LOGGING_H) */

--- a/src/ctrl.c
+++ b/src/ctrl.c
@@ -252,8 +252,13 @@ static void setup_fifo(int *fifo_r, int *fifo_w, char *filename, char *error_var
 	if (!fifo_r || !fifo_w)
 		pexitf("setup fifo was passed a NULL pointer");
 
-	if (mkfifo(fifo_path, 0666) == -1)
-		pexitf("Failed to mkfifo at %s", fifo_path);
+	if (mkfifo(fifo_path, 0666) == -1) {
+		if (errno == EEXIST) {
+			unlink(fifo_path);
+			if (mkfifo(fifo_path, 0666) == -1)
+				pexitf("Failed to mkfifo at %s", fifo_path);
+		}
+	}
 
 	if ((*fifo_r = open(fifo_path, O_RDONLY | O_NONBLOCK | O_CLOEXEC)) == -1)
 		pexitf("Failed to open %s read half", error_var_name);


### PR DESCRIPTION
when passthrough is specified, the std stream files are passed directly to the container without conmon intercepting them.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
