### PR TITLE
Cirrus: Update VM Images + Drop prior-ubuntu references

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,17 +23,15 @@ env:
     FEDORA_NAME: "fedora-34"
     PRIOR_FEDORA_NAME: "fedora-33"
     UBUNTU_NAME: "ubuntu-2104"
-    PRIOR_UBUNTU_NAME: "ubuntu-2010"
 
     # VM Image built in containers/automation_images
-    IMAGE_SUFFIX: "c5032481331085312"
+    IMAGE_SUFFIX: "c6431352024203264"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
 
     # Container FQIN's
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
     UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX}"
-    PRIOR_UBUNTU_CONTAINER_FQIN: "quay.io/libpod/prior-ubuntu_podman:${IMAGE_SUFFIX}"
 
 
 # Only github users with write-access can define or use encrypted variables


### PR DESCRIPTION
Prior-Ubuntu support is being dropped everywhere.

Ref: https://github.com/containers/podman/issues/11070
     https://github.com/containers/automation_images/pull/88

Signed-off-by: Chris Evich <cevich@redhat.com>