### PR TITLE
conmon: free userdata files before exec cleanup

### DIFF
--- a/src/conn_sock.c
+++ b/src/conn_sock.c
@@ -524,4 +524,8 @@ void close_all_readers()
 	if (local_mainfd_stdin.readers == NULL)
 		return;
 	g_ptr_array_foreach(local_mainfd_stdin.readers, close_sock, NULL);
+
+	if (remote_attach_sock.fd >= 0)
+		close(remote_attach_sock.fd);
+	remote_attach_sock.fd = -1;
 }

--- a/src/ctr_logging.c
+++ b/src/ctr_logging.c
@@ -533,6 +533,14 @@ static int set_k8s_timestamp(char *buf, ssize_t buflen, const char *pipename)
 	return err;
 }
 
+/* Force closing any open FD. */
+void close_logging_fds(void)
+{
+	if (k8s_log_fd >= 0)
+		close(k8s_log_fd);
+	k8s_log_fd = -1;
+}
+
 /* reopen all log files */
 void reopen_log_files(void)
 {

--- a/src/ctr_logging.h
+++ b/src/ctr_logging.h
@@ -10,5 +10,6 @@ bool write_to_logs(stdpipe_t pipe, char *buf, ssize_t num_read);
 void configure_log_drivers(gchar **log_drivers, int64_t log_size_max_, char *cuuid_, char *name_, char *tag);
 void sync_logs(void);
 gboolean logging_is_passthrough(void);
+void close_logging_fds(void);
 
 #endif /* !defined(CTR_LOGGING_H) */


### PR DESCRIPTION
make sure all files under the userdata directory are closed before
calling the cleanup program.

This is needed when running on NFS since unlinking a file on NFS and
keeping it open causes a "silly rename" to keep a reference to the
file and doesn't permit rm -rf to cleanup the directory correctly.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>