### PR TITLE
exit: close all fds >= 3

### DIFF
--- a/src/close_fds.c
+++ b/src/close_fds.c
@@ -80,3 +80,27 @@ void close_other_fds()
 			close(fd);
 	}
 }
+
+void close_all_fds_ge_than(int firstfd)
+{
+	struct dirent *ent;
+	DIR *d;
+
+	d = opendir("/proc/self/fd");
+	if (!d)
+		return;
+
+	for (ent = readdir(d); ent; ent = readdir(d)) {
+		int fd;
+
+		if (ent->d_name[0] == '.')
+			continue;
+
+		fd = atoi(ent->d_name);
+		if (fd == dirfd(d))
+			continue;
+		if (fd >= firstfd)
+			close(fd);
+	}
+	closedir(d);
+}

--- a/src/close_fds.h
+++ b/src/close_fds.h
@@ -1,1 +1,2 @@
 void close_other_fds();
+void close_all_fds_ge_than(int firstfd);


### PR DESCRIPTION
the current code that tries to list each open fd is error prone, and
it was missing "dummyfd" opened in main().  To avoid such issue, and
be future-proof, just iterate over the open file descriptors and close
them all!

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2040379

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>