### PR TITLE
Fix coverity issues according to #318

### DIFF
--- a/src/ctr_logging.c
+++ b/src/ctr_logging.c
@@ -295,7 +295,7 @@ int write_journald(int pipe, char *buf, ssize_t buflen)
 
 		int err = sd_journal_sendv(bufv.iov, bufv.iovcnt);
 		if (err < 0) {
-			pwarn(strerror(err));
+			pwarn(err);
 			return err;
 		}
 


### PR DESCRIPTION
As far as I can tell, the unbounded source buffer issue  is actually a false positive - syslog is not writing back to the source buffer. 

The Bad bit shift operation issue cannot happen either, as entries in /proc/self/fd start at "0" and are never negative. 

That leaves the pwarn issue, which is fixed trivially. 