### PR TITLE
Stop using g_unix_signal_add() to avoid threads

### DIFF
--- a/src/ctr_exit.h
+++ b/src/ctr_exit.h
@@ -13,11 +13,10 @@ struct pid_check_data {
 	GHashTable *exit_status_cache;
 };
 
-void on_sigchld(G_GNUC_UNUSED int signal);
 void on_sig_exit(int signal);
 void container_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointer user_data);
 gboolean check_child_processes_cb(gpointer user_data);
-gboolean on_sigusr1_cb(gpointer user_data);
+gboolean on_signalfd_cb(gint fd, GIOCondition condition, gpointer user_data);
 gboolean timeout_cb(G_GNUC_UNUSED gpointer user_data);
 int get_exit_status(int status);
 void runtime_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointer user_data);


### PR DESCRIPTION
g_unix_signal_add() is implemented via an implicitly-created worker
thread in GLib.  This thread creates an eventfd, and conflicts with
conmon's general approach to taking full ownership of all open fds in
the process.

Stop using g_unix_signal_add() and switch to using g_unix_fd_add() on a
signalfd() as an alternative approach.

Fixes #330


I tested this by running
```
podman --conmon ~/src/conmon/build/conmon exec f36 sh -c 'sleep 1000&'
```

and

```
podman --conmon /usr/bin/conmon exec f36 sh -c 'sleep 1000&'
```

and suspending my laptop.  On resume, `/usr/bin/conmon` was spinning at 100% CPU, but my patched version wasn't.

