### PR TITLE
Use /usr/bin/env to locate bash

### DIFF
--- a/hack/seccomp-notify.sh
+++ b/hack/seccomp-notify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 if $(printf '#include <linux/seccomp.h>\nvoid main(){struct seccomp_notif_sizes s;}' | cc -x c - -o /dev/null 2> /dev/null && pkg-config --atleast-version 2.5.0 libseccomp); then
         echo "0"
 fi


### PR DESCRIPTION
On FreeBSD, this lives in /usr/local/bin. Note: this pattern is already
used for the other scripts in hack.

Signed-off-by: Doug Rabson <dfr@rabson.org>