### PR TITLE
logging: do not read more that the buf size

### DIFF
--- a/src/ctr_logging.c
+++ b/src/ctr_logging.c
@@ -327,7 +327,7 @@ static int write_journald(int pipe, char *buf, ssize_t buflen)
 
 		int err = sd_journal_sendv(bufv.iov, bufv.iovcnt);
 		if (err < 0) {
-			pwarn(strerror(err));
+			pwarn(strerror(-err));
 			return err;
 		}
 


### PR DESCRIPTION
msg_len doesn't take into account NUL bytes that could be present in
the buffer, while g_strdup_printf("MESSAGE=%s%s", partial_buf, buf)
does and would stop writing the string once it finds a NUL byte.  This
would lead to read after the buffer end.

Build the message string manually so that the calculated length
reflects the buffer size.

Closes: https://github.com/containers/conmon/issues/315

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>