### PR TITLE
Fix tools/Makefile with GNU make 4.4

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,3 @@
-export GO111MODULE=off
-
 GO := go
 
 BUILDDIR := build


### PR DESCRIPTION
Before GNU make 4.4, "export" variables were not actually exported to $(shell) commands, so the `export GO111MODULE=off` line had no effect. With make >= 4.4, this variable is now set in the environment of the `go build` command, which breaks it. Just remove the wrong variable assignment to have the same behavour as previously.