### PR TITLE
Use --detach instead of -d (fix gVisor compat)

### DIFF
--- a/src/runtime_args.c
+++ b/src/runtime_args.c
@@ -27,7 +27,7 @@ GPtrArray *configure_runtime_args(const char *const csname)
 
 	/* Set the exec arguments. */
 	if (opt_exec) {
-		add_argv(runtime_argv, "exec", "--pid-file", opt_container_pid_file, "--process", opt_exec_process_spec, "-d", NULL);
+		add_argv(runtime_argv, "exec", "--pid-file", opt_container_pid_file, "--process", opt_exec_process_spec, "--detach", NULL);
 		if (opt_terminal)
 			add_argv(runtime_argv, "--tty", NULL);
 	} else {


### PR DESCRIPTION
`--detach` is supported by both `runc` and gVisor's `runsc`, while `runsc` does not support the shorthand `-d`.

https://github.com/google/gvisor/blob/master/runsc/cmd/exec.go#L99

Without this change, `runsc` errors out on `podman exec`:

~~~
Error: OCI runtime error: runsc: flag provided but not defined: -d
~~~