### PR TITLE
Fix leaking symbolic links in the opt_socket_path directory

### DIFF
--- a/src/conn_sock.c
+++ b/src/conn_sock.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 
 #include "conn_sock.h"
+#include "ctr_exit.h"
 #include "globals.h"
 #include "utils.h"
 #include "config.h"
@@ -318,6 +319,9 @@ char *socket_parent_dir(gboolean use_full_attach_path, size_t desired_len)
 
 	if (symlink(opt_bundle_path, base_path) == -1)
 		pexit("Failed to create symlink for notify socket");
+
+	// Ensure the link is deleted when we exit
+	atexit(cleanup_socket_dir_symlink);
 
 	return base_path;
 }

--- a/src/ctr_exit.c
+++ b/src/ctr_exit.c
@@ -1,7 +1,7 @@
 #define _GNU_SOURCE
 
 #include "ctr_exit.h"
-#include "cli.h" // opt_exit_command, opt_exit_delay
+#include "cli.h" // opt_exit_command, opt_exit_delay, opt_socket_path, opt_cuuid
 #include "utils.h"
 #include "parent_pipe_fd.h"
 #include "globals.h"
@@ -213,6 +213,16 @@ void reap_children()
 	   exiting */
 	while (waitpid(-1, NULL, WNOHANG) > 0)
 		;
+}
+
+void cleanup_socket_dir_symlink()
+{
+	/* A symbolic link might be created at {opt_socket_path}/{opt_cuuid} if the container
+	   is created successfully.
+	   This function will take care of removing the link when the conmon process exits. */
+	char *base_path = g_build_filename(opt_socket_path, opt_cuuid, NULL);
+	if (unlink(base_path) == -1 && errno != ENOENT)
+		pexitf("Failed to remove existing symlink for the socket directory %s", base_path);
 }
 
 void handle_signal(G_GNUC_UNUSED const int signum)

--- a/src/ctr_exit.h
+++ b/src/ctr_exit.h
@@ -23,6 +23,7 @@ void runtime_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointer 
 void container_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointer user_data);
 void do_exit_command();
 void reap_children();
+void cleanup_socket_dir_symlink();
 void handle_signal(G_GNUC_UNUSED const int signum);
 
 #endif // CTR_EXIT_H


### PR DESCRIPTION
When we create a container with crio in OKD/OCP, conmon creates a symbolic link in /var/run/crio to /run/containers/storage/overlay-containers/$cuid/userdata.
This symblic link is never removed when the container is removed, leading to several dangling symbolic links in /var/run/crio, filling up the inodes capacity in /var/run.

This PR fixes this issue by adding a function/callback to remove the symbolic link when `conmon` exits.

Refers okd-project/okd#1497 and https://issues.redhat.com/browse/OCPBUGS-7962