### PR TITLE
exit: Free allocated string

### DIFF
--- a/src/ctr_exit.c
+++ b/src/ctr_exit.c
@@ -220,7 +220,7 @@ void cleanup_socket_dir_symlink()
 	/* A symbolic link might be created at {opt_socket_path}/{opt_cuuid} if the container
 	   is created successfully.
 	   This function will take care of removing the link when the conmon process exits. */
-	char *base_path = g_build_filename(opt_socket_path, opt_cuuid, NULL);
+	_cleanup_free_ char *base_path = g_build_filename(opt_socket_path, opt_cuuid, NULL);
 	if (unlink(base_path) == -1 && errno != ENOENT)
 		pexitf("Failed to remove existing symlink for the socket directory %s", base_path);
 }


### PR DESCRIPTION
This doesn't matter since we're going to exit, but I'm sure it will show up in static analyzers.