### PR TITLE
Use default umask `0022`

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -34,9 +34,12 @@ static void disconnect_std_streams(int dev_null_r, int dev_null_w)
 		pexit("Failed to dup over stderr");
 }
 
+#define DEFAULT_UMASK 0022
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "");
+	umask(DEFAULT_UMASK);
 	_cleanup_gerror_ GError *err = NULL;
 	char buf[BUF_SIZE];
 	int num_read;


### PR DESCRIPTION
Under non-reproducible circumstances it can happen that the umask of conmon is set to `0000`, which can be a security issue. To avoid that, we now use a default umask and set it directly in `main`.

We had a similar fix in CRI-O in https://github.com/cri-o/cri-o/pull/5904, but we have to do it here again because conmon is a direct parent of PID 1.

Refers to https://issues.redhat.com/browse/OCPBUGS-8057