### PR TITLE
Support to build conmon for ppc64le

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -119,7 +119,7 @@ static_binary_task:
     # the next line and file an issue with details about the failure.
     # allow_failures: true
 
-    timeout_in: '240m'
+    timeout_in: '360m'
 
     gce_instance:
         image_name: "${FEDORA_CACHE_IMAGE_NAME}"
@@ -139,12 +139,15 @@ static_binary_task:
         CACHIX_AUTH_TOKEN: ENCRYPTED[4c3b8d82b0333abf048c56a71f2559ddb1c9ed38f0c28916eca13f79affa5904cf90c76a5bd8686680c89f41079ef341]
 
     matrix:
-      - name: "Static intel binary"
+      - name: "Static amd64 binary"
         env:
             TARGET: default.nix
-      - name: "Static ARM binary"
+      - name: "Static arm64 binary"
         env:
             TARGET: default-arm64.nix
+      - name: "Static ppc64le binary"
+        env:
+            TARGET: default-ppc64le.nix
 
     build_script: |
         set -ex

--- a/nix/default-ppc64le.nix
+++ b/nix/default-ppc64le.nix
@@ -1,0 +1,36 @@
+let
+  static = import ./static.nix;
+  pkgs = (import ./nixpkgs.nix {
+    crossSystem = { config = "powerpc64le-unknown-linux-gnu"; };
+    overlays = [
+      (final: pkg: {
+        pcre = (static pkg.pcre).overrideAttrs (x: {
+          configureFlags = x.configureFlags ++ [ "--enable-static" ];
+        });
+      })
+    ];
+    config = {
+      packageOverrides = pkg: {
+        libseccomp = (static pkg.libseccomp);
+        glib = (static pkg.glib).overrideAttrs (x: {
+          outputs = [ "bin" "out" "dev" ];
+          mesonFlags = [
+            "-Ddefault_library=static"
+            "-Ddevbindir=${placeholder ''dev''}/bin"
+            "-Dgtk_doc=false"
+            "-Dnls=disabled"
+          ];
+          postInstall = ''
+            moveToOutput "share/glib-2.0" "$dev"
+            substituteInPlace "$dev/bin/gdbus-codegen" --replace "$out" "$dev"
+            sed -i "$dev/bin/glib-gettextize" -e "s|^gettext_dir=.*|gettext_dir=$dev/share/glib-2.0/gettext|"
+            sed '1i#line 1 "${x.pname}-${x.version}/include/glib-2.0/gobject/gobjectnotifyqueue.c"' \
+              -i "$dev"/include/glib-2.0/gobject/gobjectnotifyqueue.c
+          '';
+        });
+      };
+    };
+  });
+  self = import ./derivation.nix { inherit pkgs; };
+in
+self


### PR DESCRIPTION
Support for building `conmon` for ppc64le architecture, based on [Add arm64 static build binary #239](https://github.com/containers/conmon/pull/239).

Reference:
The job `make bundles` fails in cri-o, due to the non availability of conmon binary for ppc64le architecture. -https://github.com/cri-o/cri-o/actions/runs/4933971318/jobs/8818878101?pr=6823 
Support cri-o for ppc64le - https://github.com/cri-o/cri-o/pull/6823

The nix build instructions had been validated locally.