### PR TITLE
fix compile regression on FreeBSD

### DIFF
--- a/src/oom.c
+++ b/src/oom.c
@@ -27,5 +27,6 @@ void attempt_oom_adjust(int oom_score, int *old_value)
 	close(oom_score_fd);
 #else
 	(void)oom_score;
+	(void)old_value;
 #endif
 }


### PR DESCRIPTION
`attempt_oom_adjust()` takes two variables as of #392. Since both variables are used only under Linux and the compiler complains if you don't use the second one, this adds a line in to fix that.