### PR TITLE
Bump nixos image and dependencies' version.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -129,7 +129,7 @@ static_binary_task:
 
     env:
         # Do not use 'latest', fixed-version tag for runtime stability.
-        CTR_FQIN: "docker.io/nixos/nix:2.3.6"
+        CTR_FQIN: "docker.io/nixos/nix:2.15.0"
         # Authentication token for pushing the build cache to cachix.
         # This is critical, it helps to avoid a very lengthy process of
         # statically building every dependency needed to build conmon.

--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 declare -A VERSIONS=(
-    ["cni-plugins"]=v1.1.0
-    ["runc"]=v1.1.2
-    ["bats"]=v1.2.1
+    ["cni-plugins"]=v1.3.0
+    ["runc"]=v1.1.7
+    ["bats"]=v1.9.0
 )
 
 main() {


### PR DESCRIPTION
Changes to update nix image to the latest stable release along with dependencies used in GH actions.