### PR TITLE
Fix close_other_fds on FreeBSD

### DIFF
--- a/src/close_fds.c
+++ b/src/close_fds.c
@@ -22,6 +22,12 @@
 
 #include <sys/stat.h>
 
+#ifdef __FreeBSD__
+#define OPEN_FILES_DIR "/dev/fd"
+#else
+#define OPEN_FILES_DIR "/proc/self/fd"
+#endif
+
 static int open_files_max_fd;
 static fd_set *open_files_set;
 
@@ -31,7 +37,7 @@ static void __attribute__((constructor)) init()
 	ssize_t size = 0;
 	DIR *d;
 
-	d = opendir("/proc/self/fd");
+	d = opendir(OPEN_FILES_DIR);
 	if (!d)
 		return;
 
@@ -85,7 +91,7 @@ void close_all_fds_ge_than(int firstfd)
 	struct dirent *ent;
 	DIR *d;
 
-	d = opendir("/proc/self/fd");
+	d = opendir(OPEN_FILES_DIR);
 	if (!d)
 		return;
 


### PR DESCRIPTION
While testing podman's restart policy handling, I noticed that containers which were publishing ports did not restart automatically. This was caused by conmon not properly closing the file descriptor which reserved the published port on the host before cleaning up the container. This commit lets conmon discover any extra file descriptors on FreeBSD.