### PR TITLE
Do not exit main loop before OOM check has finished

### DIFF
--- a/src/ctr_exit.c
+++ b/src/ctr_exit.c
@@ -129,7 +129,9 @@ void container_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointe
 		return;
 	}
 
+	g_mutex_lock(&mutex);
 	g_main_loop_quit(main_loop);
+	g_mutex_unlock(&mutex);
 }
 
 void do_exit_command()

--- a/src/globals.c
+++ b/src/globals.c
@@ -21,3 +21,4 @@ int dev_null_w = -1;
 gboolean timed_out = FALSE;
 
 GMainLoop *main_loop = NULL;
+GMutex mutex;

--- a/src/globals.h
+++ b/src/globals.h
@@ -26,6 +26,7 @@ extern int dev_null_w;
 extern gboolean timed_out;
 
 extern GMainLoop *main_loop;
+extern GMutex mutex;
 
 
 #endif // GLOBALS_H


### PR DESCRIPTION
While debugging conmon OOM detection logic, I saw a case when OOM callback never finished, possibly due to g_main_loop_quit() being called.

Let it finish.

PS I'm not very proficient with this code (or glib), please review carefully.