### PR TITLE
cli: log parsing errors to stderr

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -121,7 +121,7 @@ int initialize_cli(int argc, char *argv[])
 
 	GError *error = NULL;
 	if (!g_option_context_parse(context, &argc, &argv, &error)) {
-		g_print("conmon: option parsing failed: %s\n", error->message);
+		g_printerr("conmon: option parsing failed: %s\n", error->message);
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
Error messages should always be logged to stderr not stdout. I found this while working on:
https://github.com/containers/podman/pull/19635