### PR TITLE
src/seccomp_notify.c: fix static build

### DIFF
--- a/src/seccomp_notify.c
+++ b/src/seccomp_notify.c
@@ -7,7 +7,6 @@
 
 #include <errno.h>
 #include <sys/ioctl.h>
-#include <dlfcn.h>
 #include <sys/wait.h>
 #include <sys/mount.h>
 #include <signal.h>
@@ -19,6 +18,7 @@
 
 #ifdef USE_SECCOMP
 
+#include <dlfcn.h>
 #include <sys/sysmacros.h>
 #include <linux/seccomp.h>
 #include <seccomp.h>


### PR DESCRIPTION
Fix the following static build failure raised even when seccomp is disabled:

```
src/seccomp_notify.c:10:10: fatal error: dlfcn.h: No such file or directory
   10 | #include <dlfcn.h>
      |          ^~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/71b4f35b3150183c7b44bc3897f01b0019e10ebe