### PR TITLE
oom-score: restore oom score before running exit command

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -43,7 +43,6 @@ int main(int argc, char *argv[])
 	_cleanup_gerror_ GError *err = NULL;
 	char buf[BUF_SIZE];
 	int num_read;
-	int old_oom_score = 0;
 	_cleanup_close_ int dev_null_r_cleanup = -1;
 	_cleanup_close_ int dev_null_w_cleanup = -1;
 	_cleanup_close_ int dummyfd = -1;
@@ -55,7 +54,7 @@ int main(int argc, char *argv[])
 
 	process_cli();
 
-	attempt_oom_adjust(-1000, &old_oom_score);
+	attempt_oom_adjust(-1000);
 
 	/* ignoring SIGPIPE prevents conmon from being spuriously killed */
 	signal(SIGPIPE, SIG_IGN);
@@ -295,7 +294,7 @@ int main(int argc, char *argv[])
 		}
 
 		// We don't want runc to be unkillable so we reset the oom_score_adj back to 0
-		attempt_oom_adjust(old_oom_score, NULL);
+		reset_oom_adjust();
 		execv(g_ptr_array_index(runtime_argv, 0), (char **)runtime_argv->pdata);
 		exit(127);
 	}

--- a/src/ctr_exit.c
+++ b/src/ctr_exit.c
@@ -7,6 +7,7 @@
 #include "globals.h"
 #include "ctr_logging.h"
 #include "close_fds.h"
+#include "oom.h"
 
 #include <errno.h>
 #include <glib.h>
@@ -200,6 +201,8 @@ void do_exit_command()
 		ndebugf("Sleeping for %d seconds before executing exit command", opt_exit_delay);
 		sleep(opt_exit_delay);
 	}
+
+	reset_oom_adjust();
 
 	execv(opt_exit_command, args);
 

--- a/src/oom.c
+++ b/src/oom.c
@@ -5,7 +5,9 @@
 #include <string.h>
 #include <unistd.h>
 
-void attempt_oom_adjust(int oom_score, int *old_value)
+int old_oom_score = 0;
+
+static void write_oom_adjust(int oom_score, int *old_value)
 {
 #ifdef __linux__
 	char fmt_oom_score[16];
@@ -29,4 +31,14 @@ void attempt_oom_adjust(int oom_score, int *old_value)
 	(void)oom_score;
 	(void)old_value;
 #endif
+}
+
+void attempt_oom_adjust(int oom_score)
+{
+	write_oom_adjust(oom_score, &old_oom_score);
+}
+
+void reset_oom_adjust()
+{
+	write_oom_adjust(old_oom_score, NULL);
 }

--- a/src/oom.h
+++ b/src/oom.h
@@ -1,6 +1,7 @@
 #if !defined(OOM_H)
 #define OOM_H
 
-void attempt_oom_adjust(int oom_score, int *old_value);
+void attempt_oom_adjust(int oom_score);
+void reset_oom_adjust();
 
 #endif // OOM_H


### PR DESCRIPTION
When the exit command is executed, the oom score is restored to its original value otherwise the command runs with -1000.

Closes: https://github.com/containers/podman/issues/20765