### PR TITLE
src: fix write after end of buffer

### DIFF
--- a/src/conn_sock.c
+++ b/src/conn_sock.c
@@ -416,7 +416,7 @@ static gboolean read_remote_sock(struct remote_sock_s *sock)
 	}
 
 	if (SOCK_IS_STREAM(sock->sock_type)) {
-		num_read = read(sock->fd, sock->buf, CONN_SOCK_BUF_SIZE);
+		num_read = read(sock->fd, sock->buf, CONN_SOCK_BUF_SIZE - 1);
 	} else {
 		num_read = recvfrom(sock->fd, sock->buf, CONN_SOCK_BUF_SIZE - 1, 0, NULL, NULL);
 	}


### PR DESCRIPTION
we hardcode `sock->buf[num_read] = '\0';` so num_read cannot be equal to the size of the buffer.