### PR TITLE
Fix podman tests

### DIFF
--- a/src/conn_sock.c
+++ b/src/conn_sock.c
@@ -416,9 +416,9 @@ static gboolean read_remote_sock(struct remote_sock_s *sock)
 	}
 
 	if (SOCK_IS_STREAM(sock->sock_type)) {
-		num_read = read(sock->fd, sock->buf, CONN_SOCK_BUF_SIZE - 1);
+		num_read = read(sock->fd, sock->buf, CONN_SOCK_BUF_SIZE);
 	} else {
-		num_read = recvfrom(sock->fd, sock->buf, CONN_SOCK_BUF_SIZE - 1, 0, NULL, NULL);
+		num_read = recvfrom(sock->fd, sock->buf, CONN_SOCK_BUF_SIZE, 0, NULL, NULL);
 	}
 
 	if (num_read < 0)

--- a/src/conn_sock.h
+++ b/src/conn_sock.h
@@ -36,7 +36,7 @@ struct remote_sock_s {
 	gboolean writable;
 	size_t remaining;
 	size_t off;
-	char buf[CONN_SOCK_BUF_SIZE];
+	char buf[CONN_SOCK_BUF_SIZE + 1]; // Extra byte allows null-termination
 };
 
 struct local_sock_s {


### PR DESCRIPTION
The change in commit 3605a368ea9c2d946e3f694c36dfc11c8e92b3d9 broke the podman test/system tests:

```
 ✗ [075] podman exec - cat from stdin
   (from function `bail-now' in file test/system/helpers.bash, line 227,
    from function `is' in file test/system/helpers.bash, line 956,
    in test file test/system/075-exec.bats, line 84)
     `is "${lines[0]}" "3000+0 records in"  "dd: number of records in"' failed
   [11:10:24.237041104] $ /vcs/other/podman/bin/podman rm -t 0 --all --force --ignore
   [11:10:24.272179180] $ /vcs/other/podman/bin/podman ps --all --external --format {{.ID}} {{.Names}}
   [11:10:24.307984108] $ /vcs/other/podman/bin/podman images --all --format {{.Repository}}:{{.Tag}} {{.ID}}
   [11:10:24.339679735] quay.io/libpod/systemd-image:20230531 9984d4cfd1eb  quay.io/libpod/testimage:20221018 f5a99120db64
   [11:10:24.357682655] $ /vcs/other/podman/bin/podman run -d quay.io/libpod/testimage:20221018 top
   [11:10:24.499542609] 76f963b708fe74814e8e078bbc41af84368beafaad2da932dc4ee7c3d6629409
   [11:10:24.512104004] $ /vcs/other/podman/bin/podman exec -i 76f963b708fe74814e8e078bbc41af84368beafaad2da932dc4ee7c3d6629409 cat
   [11:10:24.648299147] of9AOlHs62yCSNsgYav5
   1500+0 records in
   1500+0 records out
   1536000 bytes (1,5 MB, 1,5 MiB) copied, 0,00696935 s, 220 MB/s
   [11:10:24.670650275] $ /vcs/other/podman/bin/podman exec -i 76f963b708fe74814e8e078bbc41af84368beafaad2da932dc4ee7c3d6629409 dd of=/tmp/bigfile bs=512
   [11:10:24.768570699] 2999+1 records in
   2999+1 records out
   #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
   #|     FAIL: dd: number of records in
   #| expected: '3000+0 records in'
   #|   actual: '2999+1 records in'
   #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I'm not sure exactly why the socket buffer read size matters here, but changing it back to reading exactly 32k fixes the test again.

To keep the fix from https://github.com/containers/conmon/pull/467 I added an extra byte to the buffer. However, I wonder if that change was strictly needed, as the `sock->buf[num_read] = '\0'` code is only used for the notify case, which is not a streaming socket.