### PR TITLE
Fix incorrect free in conn_sock

### DIFF
--- a/src/conn_sock.c
+++ b/src/conn_sock.c
@@ -314,7 +314,7 @@ char *socket_parent_dir(gboolean use_full_attach_path, size_t desired_len)
 {
 	/* if we're to use the full path, ignore the socket path and only use the bundle_path */
 	if (use_full_attach_path)
-		return opt_bundle_path;
+		return strdup(opt_bundle_path);
 
 	char *base_path = g_build_filename(opt_socket_path, opt_cuuid, NULL);
 


### PR DESCRIPTION
Earlier commit freed socket_parent_dir()'s result which is correct in the case it returns a path from g_build_filename, but when it returns opt_bundle_path the string should not be freed.

Make the function always return an allocated string that can be freed

Fixes: #475
Fixes: fad6bac8e65f ("fix some issues flagged by SAST scan")