### PR TITLE
Make 'docs' target not depend on 'install.tools' if GOMD2MAN is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,10 @@ vendor:
 	GO111MODULE=on $(GO) mod verify
 
 .PHONY: docs
+ifeq ($(GOMD2MAN),)
 docs: install.tools
+endif
+docs:
 	$(MAKE) -C docs
 
 .PHONY: clean


### PR DESCRIPTION
If the GOMD2MAN (environment) variable is set, then we do not need the 'docs' target to depend on 'install.tools', which will build gomd2man.

This avoids gomd2man to be build, even though the user already request the usage of a particular gomd2man binary. It also removes an implicit build dependency on go. The latter causes downstream bugs like https://bugs.gentoo.org/931645