### PR TITLE
Use `.gitignore` in nix build excludes

### DIFF
--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -3,7 +3,8 @@
 }:
 with pkgs; stdenv.mkDerivation rec {
   name = "conmon";
-  src = ./..;
+  # Use Pure to avoid exuding the .git directory
+  src = nix-gitignore.gitignoreSourcePure [ ../.gitignore ] ./..;
   vendorHash = null;
   doCheck = false;
   enableParallelBuilding = true;


### PR DESCRIPTION
This avoids building with wrong pre-built data locally as well as in CI.