### PR TITLE
RPM: delete unnecessary patching from spec

### DIFF
--- a/rpm/conmon.spec
+++ b/rpm/conmon.spec
@@ -47,7 +47,6 @@ Requires: libseccomp
 %prep
 %autosetup -Sgit %{name}-%{version}
 sed -i 's/install.bin: bin\/conmon/install.bin:/' Makefile
-sed -i 's/install.crio: bin\/conmon/install.crio:/' Makefile
 
 %build
 %{__make} DEBUGFLAG="-g" bin/conmon


### PR DESCRIPTION
Forgot to remove it in the previous PR where crio installation was removed from rpm.
