### PR TITLE
Packit: constrain downstream jobs to the fedora package

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -78,10 +78,12 @@ jobs:
 
   - job: koji_build
     trigger: commit
+    packages: [conmon-fedora]
     dist_git_branches:
       - fedora-all
 
   - job: bodhi_update
     trigger: commit
+    packages: [conmon-fedora]
     dist_git_branches:
       - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
Without this constraint, packit triggers dup jobs for downstream updates.