### PR TITLE
Avoid bogus journal filling errors

### DIFF
--- a/docs/conmon.8.md
+++ b/docs/conmon.8.md
@@ -38,7 +38,7 @@ Path to the process spec for execution.
 Path to the program to execute when the container terminates its execution.
 
 **--exit-command-arg**
-Additional arguments to pass to the exit command.  Can be specified multiple time.
+Additional arguments to pass to the exit command.  Can be specified multiple times.
 
 **--exit-delay**
 Delay before invoking the exit command (in seconds).
@@ -64,7 +64,7 @@ Leave stdin open when the attached client disconnects.
 Print debug logs based on the log level.
 
 **--log-size-max**
-Maximum size of the log file.
+Maximum size of the log file (in bytes).
 
 **--log-tag**
 Additional tag to use for logging.
@@ -94,7 +94,7 @@ PID file for the conmon process.
 Path to store runtime data for the container.
 
 **--replace-listen-pid**
-Replace listen pid if set for oci-runtime pid.
+Replace listen PID if set for oci-runtime PID.
 
 **--restore**
 Restore a container from a checkpoint.
@@ -106,7 +106,7 @@ Additional arguments to pass to the runtime. Can be specified multiple times.
 Additional options to pass to the restore or exec command. Can be specified multiple times.
 
 **-s**, **--systemd-cgroup**
-Enable systemd cgroup manager, rather then use the cgroupfs directly.
+Enable systemd cgroup manager, rather than use the cgroupfs directly.
 
 **--socket-dir-path**
 Location of container attach sockets.

--- a/src/utils.c
+++ b/src/utils.c
@@ -49,17 +49,10 @@ void set_conmon_logs(char *level_name, char *cid_, gboolean syslog_, char *tag)
 	nexitf("No such log level %s", level_name);
 }
 
-#ifdef __FreeBSD__
 static bool retryable_error(int err)
 {
-	return err == EINTR || err == EAGAIN;
+	return err == EINTR || err == EAGAIN || err == ENOBUFS;
 }
-#else
-static bool retryable_error(int err)
-{
-	return err == EINTR;
-}
-#endif
 
 static void get_signal_descriptor_mask(sigset_t *set)
 {


### PR DESCRIPTION
Issue #454 is likely caused by retryable_error() not catching all possible retryable errors from the write(2) syscall.

This PR should be FeeBSD compatible. The only retriable result in question is ENOBUFS which might be bound to network latencies. Hope these are acceptable.

Signed-off-by: Jindrich Novy <jnovy@redhat.com>
