### PR TITLE
sock_try_write_to_local_sock: improve a warning

### DIFF
--- a/src/conn_sock.c
+++ b/src/conn_sock.c
@@ -563,7 +563,7 @@ static void sock_try_write_to_local_sock(struct remote_sock_s *sock)
 			   (struct sockaddr *)local_sock->addr, sizeof(*(local_sock->addr)));
 	}
 	if (w < 0) {
-		nwarnf("Failed to write %s", local_sock->label);
+		nwarnf("Failed to %s %s: %m", (local_sock->is_stream) ? "write" : "sendto", local_sock->label);
 	} else {
 		sock->off += w;
 		sock->remaining -= w;


### PR DESCRIPTION
Make sure we show errno, and tell if the write was to a socket.

Related to #540. Alternative to #554.