### PR TITLE
seccomp_accept_cb: fix memory leak

### DIFF
--- a/src/seccomp_notify.c
+++ b/src/seccomp_notify.c
@@ -79,6 +79,7 @@ gboolean seccomp_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC_
 	if (listener.fd < 0) {
 		pexit("Failed to receive socket listener file descriptor");
 	}
+	free(listener.name);
 
 	_cleanup_free_ char *oci_config_path = g_strdup_printf("%s/config.json", opt_bundle_path);
 	if (oci_config_path == NULL) {


### PR DESCRIPTION
Users of recvfd are expected to free the `.name`.