### PR TITLE
include the correct header for syscall definitions

### DIFF
--- a/src/seccomp_notify.c
+++ b/src/seccomp_notify.c
@@ -21,7 +21,7 @@
 #include <dlfcn.h>
 #include <sys/sysmacros.h>
 #include <linux/seccomp.h>
-#include <seccomp.h>
+#include <asm/unistd.h>
 
 #include "seccomp_notify.h"
 


### PR DESCRIPTION
This file needs to utilize `__NR_seccomp`, which is defined in the linux uapi headers, not seccomp.h, even though seccomp.h does itself indirectly cause this header to be included as well.

Nothing else in this particular file needs seccomp.h so drop that include altogether since it's now entirely unused.