### PR TITLE
Modernize Go code

### DIFF
--- a/cmd/conmon-config/conmon-config.go
+++ b/cmd/conmon-config/conmon-config.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/containers/conmon/runner/config"
 )
@@ -23,7 +23,7 @@ func main() {
 
 #endif // CONFIG_H
 `
-	if err := ioutil.WriteFile("config.h", []byte(fmt.Sprintf(
+	if err := os.WriteFile("config.h", []byte(fmt.Sprintf(
 		output,
 		config.BufSize,
 		config.BufSize,

--- a/cmd/conmon-config/conmon-config.go
+++ b/cmd/conmon-config/conmon-config.go
@@ -32,7 +32,7 @@ func main() {
 		config.WinResizeEvent,
 		config.ReopenLogsEvent,
 		config.TimedOutMessage)),
-		0644); err != nil {
+		0o644); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
 	github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc
-	github.com/pkg/errors v0.9.1
 	golang.org/x/sys v0.20.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,6 @@ github.com/opencontainers/runtime-spec v1.1.0-rc.3/go.mod h1:jwyrGlmzljRJv/Fgzds
 github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc h1:d2hUh5O6MRBvStV55MQ8we08t42zSTqBbscoQccWmMc=
 github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc/go.mod h1:8tx1helyqhUC65McMm3x7HmOex8lO2/v9zPuxmKHurs=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/runner/conmon/conmon.go
+++ b/runner/conmon/conmon.go
@@ -1,18 +1,16 @@
 package conmon
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
-
-	"github.com/pkg/errors"
 )
 
-var (
-	ErrConmonNotStarted = errors.New("conmon instance is not started")
-)
+var ErrConmonNotStarted = errors.New("conmon instance is not started")
 
 type ConmonInstance struct {
 	args    []string
@@ -99,7 +97,7 @@ func (ci *ConmonInstance) Stderr() (io.Writer, error) {
 
 func (ci *ConmonInstance) Pid() (int, error) {
 	if ci.pidFile == "" {
-		return -1, errors.Errorf("conmon pid file not specified")
+		return -1, errors.New("conmon pid file not specified")
 	}
 	if !ci.started {
 		return -1, ErrConmonNotStarted
@@ -107,7 +105,7 @@ func (ci *ConmonInstance) Pid() (int, error) {
 
 	pid, err := readConmonPidFile(ci.pidFile)
 	if err != nil {
-		return -1, errors.Wrapf(err, "failed to find conmon pid file")
+		return -1, fmt.Errorf("failed to get conmon pid: %w", err)
 	}
 	return pid, nil
 }

--- a/runner/conmon/conmon.go
+++ b/runner/conmon/conmon.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -114,7 +113,7 @@ func (ci *ConmonInstance) Pid() (int, error) {
 func readConmonPidFile(pidFile string) (int, error) {
 	// Let's try reading the Conmon pid at the same time.
 	if pidFile != "" {
-		contents, err := ioutil.ReadFile(pidFile)
+		contents, err := os.ReadFile(pidFile)
 		if err != nil {
 			return -1, err
 		}

--- a/runner/conmon/pipes.go
+++ b/runner/conmon/pipes.go
@@ -128,14 +128,6 @@ func getOCIRuntimeError(runtimeMsg string) error {
 	return fmt.Errorf("%s: %w", strings.Trim(runtimeMsg, "\n"), ErrOCIRuntime)
 }
 
-// writeConmonPipeData writes data to a pipe. The actual content does not matter
-// as it is used as a signal for conmon to stop blocking on a read
-func writeConmonPipeData(pipe *os.File) error {
-	someData := []byte{0}
-	_, err := pipe.Write(someData)
-	return err
-}
-
 func (ci *ConmonInstance) closePipesOnCleanup() {
 	ci.parentSyncPipe.Close()
 	ci.parentStartPipe.Close()

--- a/runner/conmon/pipes.go
+++ b/runner/conmon/pipes.go
@@ -3,13 +3,12 @@ package conmon
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // These errors are adapted from github.com/containers/podman:libpod/define
@@ -29,10 +28,10 @@ var (
 
 func (ci *ConmonInstance) configurePipeEnv() error {
 	if ci.cmd == nil {
-		return errors.Errorf("conmon instance command must be configured")
+		return errors.New("conmon instance command must be configured")
 	}
 	if ci.started {
-		return errors.Errorf("conmon instance environment cannot be configured after it's started")
+		return errors.New("conmon instance environment cannot be configured after it's started")
 	}
 	// TODO handle PreserveFDs
 	preserveFDs := 0
@@ -92,17 +91,17 @@ func readConmonPipeData(pipe *os.File) (int, error) {
 	select {
 	case ss := <-ch:
 		if ss.err != nil {
-			return -1, errors.Wrapf(ss.err, "error received on processing data from conmon pipe")
+			return -1, fmt.Errorf("error received on processing data from conmon pipe: %w", ss.err)
 		}
 		if ss.si.Data < 0 {
 			if ss.si.Message != "" {
 				return ss.si.Data, getOCIRuntimeError(ss.si.Message)
 			}
-			return ss.si.Data, errors.Wrapf(ErrInternal, "conmon invocation failed")
+			return ss.si.Data, fmt.Errorf("conmon invocation failed: %w", ErrInternal)
 		}
 		data = ss.si.Data
 	case <-time.After(1 * time.Minute):
-		return -1, errors.Wrapf(ErrInternal, "conmon invocation timeout")
+		return -1, fmt.Errorf("conmon invocation timeout: %w", ErrInternal)
 	}
 	return data, nil
 }
@@ -117,16 +116,16 @@ func getOCIRuntimeError(runtimeMsg string) error {
 		if includeFullOutput {
 			errStr = runtimeMsg
 		}
-		return errors.Wrapf(ErrOCIRuntimePermissionDenied, "%s", strings.Trim(errStr, "\n"))
+		return fmt.Errorf("%s: %w", strings.Trim(errStr, "\n"), ErrOCIRuntimePermissionDenied)
 	}
 	if match := regexp.MustCompile("(?i).*executable file not found in.*|.*no such file or directory.*").FindString(runtimeMsg); match != "" {
 		errStr := match
 		if includeFullOutput {
 			errStr = runtimeMsg
 		}
-		return errors.Wrapf(ErrOCIRuntimeNotFound, "%s", strings.Trim(errStr, "\n"))
+		return fmt.Errorf("%s: %w", strings.Trim(errStr, "\n"), ErrOCIRuntimeNotFound)
 	}
-	return errors.Wrapf(ErrOCIRuntime, "%s", strings.Trim(runtimeMsg, "\n"))
+	return fmt.Errorf("%s: %w", strings.Trim(runtimeMsg, "\n"), ErrOCIRuntime)
 }
 
 // writeConmonPipeData writes data to a pipe. The actual content does not matter

--- a/runner/conmon_test/conmon_test.go
+++ b/runner/conmon_test/conmon_test.go
@@ -1,6 +1,7 @@
 package conmon_test
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,7 +10,6 @@ import (
 	"github.com/containers/conmon/runner/conmon"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 

--- a/runner/conmon_test/conmon_test.go
+++ b/runner/conmon_test/conmon_test.go
@@ -3,7 +3,6 @@ package conmon_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -65,10 +64,9 @@ var _ = Describe("conmon", func() {
 		var tmpLogPath string
 		var origCwd string
 		BeforeEach(func() {
-			d, err := ioutil.TempDir(os.TempDir(), "conmon-")
-			Expect(err).To(BeNil())
-			tmpDir = d
+			tmpDir = GinkgoT().TempDir()
 			tmpLogPath = filepath.Join(tmpDir, "log")
+			var err error
 			origCwd, err = os.Getwd()
 			Expect(err).To(BeNil())
 		})

--- a/runner/conmon_test/ctr_logs_test.go
+++ b/runner/conmon_test/ctr_logs_test.go
@@ -1,7 +1,6 @@
 package conmon_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -15,13 +14,8 @@ var _ = Describe("conmon ctr logs", func() {
 	var tmpLogPath string
 	const invalidLogDriver = "invalid"
 	BeforeEach(func() {
-		d, err := ioutil.TempDir(os.TempDir(), "conmon-")
-		Expect(err).To(BeNil())
-		tmpDir = d
+		tmpDir = GinkgoT().TempDir()
 		tmpLogPath = filepath.Join(tmpDir, "log")
-	})
-	AfterEach(func() {
-		Expect(os.RemoveAll(tmpDir)).To(BeNil())
 	})
 	It("no log driver should fail", func() {
 		_, stderr := getConmonOutputGivenLogOpts()

--- a/runner/conmon_test/runtime_test.go
+++ b/runner/conmon_test/runtime_test.go
@@ -82,7 +82,7 @@ var _ = Describe("runc", func() {
 })
 
 func getFileContents(filename string) string {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	Expect(err).To(BeNil())
 	return string(b)
 }

--- a/runner/conmon_test/runtime_test.go
+++ b/runner/conmon_test/runtime_test.go
@@ -2,7 +2,6 @@ package conmon_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -26,9 +25,7 @@ var _ = Describe("runc", func() {
 		Expect(cacheBusyBox()).To(BeNil())
 
 		// create tmpDir
-		d, err := ioutil.TempDir(os.TempDir(), "conmon-")
-		Expect(err).To(BeNil())
-		tmpDir = d
+		tmpDir = GinkgoT().TempDir()
 
 		// generate logging path
 		tmpLogPath = filepath.Join(tmpDir, "log")
@@ -47,11 +44,10 @@ var _ = Describe("runc", func() {
 		Expect(os.Chmod(busyboxPath, 0777)).To(BeNil())
 
 		// finally, create config.json
-		_, err = generateRuntimeConfig(tmpDir, tmpRootfs)
+		_, err := generateRuntimeConfig(tmpDir, tmpRootfs)
 		Expect(err).To(BeNil())
 	})
 	AfterEach(func() {
-		Expect(os.RemoveAll(tmpDir)).To(BeNil())
 		Expect(runRuntimeCommand("delete", "-f", ctrID)).To(BeNil())
 	})
 	It("simple runtime test", func() {

--- a/runner/conmon_test/runtime_test.go
+++ b/runner/conmon_test/runtime_test.go
@@ -35,13 +35,13 @@ var _ = Describe("runc", func() {
 
 		// create the rootfs of the "container"
 		tmpRootfs = filepath.Join(tmpDir, "rootfs")
-		Expect(os.MkdirAll(tmpRootfs, 0755)).To(BeNil())
+		Expect(os.MkdirAll(tmpRootfs, 0o755)).To(BeNil())
 
 		tmpPidFile = filepath.Join(tmpDir, "pidfile")
 
 		busyboxPath := filepath.Join(tmpRootfs, "busybox")
 		Expect(os.Link(busyboxDest, busyboxPath)).To(BeNil())
-		Expect(os.Chmod(busyboxPath, 0777)).To(BeNil())
+		Expect(os.Chmod(busyboxPath, 0o777)).To(BeNil())
 
 		// finally, create config.json
 		_, err := generateRuntimeConfig(tmpDir, tmpRootfs)

--- a/runner/conmon_test/suite_test.go
+++ b/runner/conmon_test/suite_test.go
@@ -25,7 +25,6 @@ var (
 	ctrID          = "abcdefghijklm"
 	validPath      = "/tmp"
 	invalidPath    = "/not/a/path"
-	skopeoPath     = "/usr/bin/skopeo"
 )
 
 func TestConmon(t *testing.T) {

--- a/runner/conmon_test/suite_test.go
+++ b/runner/conmon_test/suite_test.go
@@ -131,13 +131,13 @@ func cacheBusyBox() error {
 	if _, err := os.Stat(busyboxDest); err == nil {
 		return nil
 	}
-	if err := os.MkdirAll(busyboxDestDir, 0755); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(busyboxDestDir, 0o755); err != nil && !os.IsExist(err) {
 		return err
 	}
 	if err := downloadFile(busyboxSource, busyboxDest); err != nil {
 		return err
 	}
-	if err := os.Chmod(busyboxDest, 0777); err != nil {
+	if err := os.Chmod(busyboxDest, 0o777); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This fixes a few minor issues with go code in this repo:
 - stop using unmaintained pkg/errors (in favor of standard Go error wrapping);
 - stop using deprecated io/ioutil;
 - remove unused code and data;
 - format octal numbers with `0o` prefix.