### PR TITLE
logging: Add container labels to log entries on journald

### DIFF
--- a/docs/conmon.8.md
+++ b/docs/conmon.8.md
@@ -69,6 +69,10 @@ Maximum size of the log file (in bytes).
 **--log-tag**
 Additional tag to use for logging.
 
+**--log-label**
+Additional label to use for logging.  The accepted format is LABEL=VALUE.  Can be specified multiple times.
+Note that LABEL must contain only uppercase letters, numbers and underscore character.
+
 **-n**, **--name**
 Container name.
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -49,6 +49,7 @@ int opt_exit_delay = 0;
 gboolean opt_replace_listen_pid = FALSE;
 char *opt_log_level = NULL;
 char *opt_log_tag = NULL;
+gchar **opt_log_labels = NULL;
 gboolean opt_sync = FALSE;
 gboolean opt_no_sync_log = FALSE;
 char *opt_sdnotify_socket = NULL;
@@ -78,6 +79,8 @@ GOptionEntry opt_entries[] = {
 	{"log-size-max", 0, 0, G_OPTION_ARG_INT64, &opt_log_size_max, "Maximum size of log file", NULL},
 	{"log-global-size-max", 0, 0, G_OPTION_ARG_INT64, &opt_log_global_size_max, "Maximum size of all log files", NULL},
 	{"log-tag", 0, 0, G_OPTION_ARG_STRING, &opt_log_tag, "Additional tag to use for logging", NULL},
+	{"log-label", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_log_labels,
+	 "Additional label to include in logs. Can be specified multiple times", NULL},
 	{"name", 'n', 0, G_OPTION_ARG_STRING, &opt_name, "Container name", NULL},
 	{"no-new-keyring", 0, 0, G_OPTION_ARG_NONE, &opt_no_new_keyring, "Do not create a new session keyring for the container", NULL},
 	{"no-pivot", 0, 0, G_OPTION_ARG_NONE, &opt_no_pivot, "Do not use pivot_root", NULL},
@@ -194,5 +197,5 @@ void process_cli()
 	if (opt_container_pid_file == NULL)
 		opt_container_pid_file = g_strdup_printf("%s/pidfile-%s", cwd, opt_cid);
 
-	configure_log_drivers(opt_log_path, opt_log_size_max, opt_log_global_size_max, opt_cid, opt_name, opt_log_tag);
+	configure_log_drivers(opt_log_path, opt_log_size_max, opt_log_global_size_max, opt_cid, opt_name, opt_log_tag, opt_log_labels);
 }

--- a/src/ctr_logging.h
+++ b/src/ctr_logging.h
@@ -7,7 +7,8 @@
 
 void reopen_log_files(void);
 bool write_to_logs(stdpipe_t pipe, char *buf, ssize_t num_read);
-void configure_log_drivers(gchar **log_drivers, int64_t log_size_max_, int64_t log_global_size_max_, char *cuuid_, char *name_, char *tag);
+void configure_log_drivers(gchar **log_drivers, int64_t log_size_max_, int64_t log_global_size_max_, char *cuuid_, char *name_, char *tag,
+			   gchar **labels);
 void sync_logs(void);
 gboolean logging_is_passthrough(void);
 void close_logging_fds(void);


### PR DESCRIPTION
At present it's not possible to ship properly labeled logs when using podman and tools like podman-compose. Container labels are lost which makes it much harder to understand where a particular log line originated from. Log processing and analysis is significantly more inconvenient as well, because it's hard to group related logs, e.g. coming from the same compose project.

This commit implements the parts necessary to annotate log messages with container labels. Each label and value pair is specified via --log-label LABEL=VALUE arguments.

This PR was initially based on https://github.com/containers/conmon/pull/553 and ultimately was reworked enough that there's little semblance to the original PR anymore. Attribution is still preserved in commit message. The following is the changes from the 553 PR:
 - the labels are now passed via multiple input arguments. This avoids whole comma-delimited string parsing code and any additional limitations on the label values.
 - added checks against invalid labels or `--log-label` being used with k8s-file
 - added documentation
 - tested with patched `podman` and currently runs in production. Podman PR: https://github.com/containers/podman/pull/26203.

Fixes #336.