### PR TITLE
OCPBUGS-4556: src: Fix terminal resize event processing

### DIFF
--- a/src/ctrl.c
+++ b/src/ctrl.c
@@ -187,7 +187,7 @@ static gboolean read_from_ctrl_buffer(int fd, gboolean (*line_process_func)(char
 	char *newline = strchrnul(beg, '\n');
 	/* Process each message which ends with a line */
 	while (*newline != '\0') {
-		if (!line_process_func(ctlbuf))
+		if (!line_process_func(beg))
 			return G_SOURCE_CONTINUE;
 
 		beg = newline + 1;


### PR DESCRIPTION
When multiple resize events are sent rapidly, only the first event was being processed correctly. Subsequent events in the
same buffer were ignored because `read_from_ctrl_buffer()` always processed from the beginning of the buffer instead of the current line position. This caused terminals to get stuck at incorrect dimensions, particularly during kubectl/oc debug sessions where resize events are common. The fix ensures each complete line in the control buffer is processed exactly once by passing the correct line start position to the processing function and properly null-terminating each line.