### PR TITLE
ci: use "stable" and "oldstable" Go versions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,11 +11,14 @@ jobs:
 
   conmon:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [stable, oldstable]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: ${{ matrix.go-version }}
       - run: sudo hack/github-actions-setup
       - name: Run conmon integration tests
         run: |
@@ -24,11 +27,14 @@ jobs:
 
   cri-o:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [stable, oldstable]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: ${{ matrix.go-version }}
       - run: sudo hack/github-actions-setup
       - name: Run CRI-O integration tests
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,8 +7,6 @@ on:
       - main
       - release-*
   pull_request:
-env:
-  GO_VERSION: 1.24
 permissions:
   contents: read
 
@@ -21,7 +19,7 @@ jobs:
     - name: install go
       uses: actions/setup-go@v5
       with:
-        go-version: "${{ env.GO_VERSION }}"
+        go-version: stable
     - name: Verify Go dependencies
       run: |
         make vendor


### PR DESCRIPTION
See individual commits for details.

Closes: #548.