### PR TITLE
Add --no-container-partial-message option

### DIFF
--- a/docs/conmon.8.md
+++ b/docs/conmon.8.md
@@ -73,6 +73,11 @@ Additional tag to use for logging.
 Additional label to use for logging.  The accepted format is LABEL=VALUE.  Can be specified multiple times.
 Note that LABEL must contain only uppercase letters, numbers and underscore character.
 
+**--no-container-partial-message**
+Do not set CONTAINER_PARTIAL_MESSAGE=true for partial lines in journald logs. This prevents
+splitting of long log lines into multiple journal entries, which can be problematic for
+systems that parse structured logs like JSON. Only affects journald log driver.
+
 **-n**, **--name**
 Container name.
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -50,6 +50,7 @@ gboolean opt_replace_listen_pid = FALSE;
 char *opt_log_level = NULL;
 char *opt_log_tag = NULL;
 gchar **opt_log_labels = NULL;
+gboolean opt_no_container_partial_message = FALSE;
 gboolean opt_sync = FALSE;
 gboolean opt_no_sync_log = FALSE;
 char *opt_sdnotify_socket = NULL;
@@ -81,6 +82,8 @@ GOptionEntry opt_entries[] = {
 	{"log-tag", 0, 0, G_OPTION_ARG_STRING, &opt_log_tag, "Additional tag to use for logging", NULL},
 	{"log-label", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_log_labels,
 	 "Additional label to include in logs. Can be specified multiple times", NULL},
+	{"no-container-partial-message", 0, 0, G_OPTION_ARG_NONE, &opt_no_container_partial_message,
+	 "Do not set CONTAINER_PARTIAL_MESSAGE=true for partial lines in journald logs (journald driver only)", NULL},
 	{"name", 'n', 0, G_OPTION_ARG_STRING, &opt_name, "Container name", NULL},
 	{"no-new-keyring", 0, 0, G_OPTION_ARG_NONE, &opt_no_new_keyring, "Do not create a new session keyring for the container", NULL},
 	{"no-pivot", 0, 0, G_OPTION_ARG_NONE, &opt_no_pivot, "Do not use pivot_root", NULL},
@@ -198,4 +201,9 @@ void process_cli()
 		opt_container_pid_file = g_strdup_printf("%s/pidfile-%s", cwd, opt_cid);
 
 	configure_log_drivers(opt_log_path, opt_log_size_max, opt_log_global_size_max, opt_cid, opt_name, opt_log_tag, opt_log_labels);
+
+	/* Warn if --no-container-partial-message is used without journald logging */
+	if (opt_no_container_partial_message && !logging_is_journald_enabled()) {
+		nwarnf("--no-container-partial-message has no effect without journald log driver");
+	}
 }

--- a/src/cli.h
+++ b/src/cli.h
@@ -40,6 +40,8 @@ extern int opt_exit_delay;
 extern gboolean opt_replace_listen_pid;
 extern char *opt_log_level;
 extern char *opt_log_tag;
+extern gchar **opt_log_labels;
+extern gboolean opt_no_container_partial_message;
 extern gboolean opt_no_sync_log;
 extern gboolean opt_sync;
 extern char *opt_sdnotify_socket;

--- a/src/ctr_logging.c
+++ b/src/ctr_logging.c
@@ -98,6 +98,11 @@ gboolean logging_is_passthrough(void)
 	return use_logging_passthrough;
 }
 
+gboolean logging_is_journald_enabled(void)
+{
+	return use_journald_logging;
+}
+
 static int count_chars_in_string(const char *str, char ch)
 {
 	int count = 0;
@@ -379,7 +384,8 @@ static int write_journald(int pipe, char *buf, ssize_t buflen)
 			return -1;
 
 		/* per docker journald logging format, CONTAINER_PARTIAL_MESSAGE is set to true if it's partial, but otherwise not set. */
-		if (partial && writev_buffer_append_segment_no_flush(&bufv, "CONTAINER_PARTIAL_MESSAGE=true", PARTIAL_MESSAGE_EQ_LEN) < 0)
+		if (partial && !opt_no_container_partial_message
+		    && writev_buffer_append_segment_no_flush(&bufv, "CONTAINER_PARTIAL_MESSAGE=true", PARTIAL_MESSAGE_EQ_LEN) < 0)
 			return -1;
 		if (container_labels) {
 			for (gchar **label = container_labels; *label; ++label) {

--- a/src/ctr_logging.h
+++ b/src/ctr_logging.h
@@ -11,6 +11,7 @@ void configure_log_drivers(gchar **log_drivers, int64_t log_size_max_, int64_t l
 			   gchar **labels);
 void sync_logs(void);
 gboolean logging_is_passthrough(void);
+gboolean logging_is_journald_enabled(void);
 void close_logging_fds(void);
 
 #endif /* !defined(CTR_LOGGING_H) */

--- a/test/02-ctr-logs.bats
+++ b/test/02-ctr-logs.bats
@@ -58,6 +58,17 @@ run_conmon_with_log_opts() {
     [ -f "$LOG_PATH" ]
 }
 
+@test "ctr logs: --no-container-partial-message option should pass with journald" {
+    run_conmon_with_log_opts --log-path "journald:" --no-container-partial-message
+    assert_success
+}
+
+@test "ctr logs: --no-container-partial-message should warn without journald" {
+    run_conmon_with_log_opts --log-path "$LOG_PATH" --no-container-partial-message
+    assert_success
+    assert_output_contains "no effect without journald log driver"
+}
+
 @test "ctr logs: multiple log drivers with one invalid should fail" {
     local invalid_log_driver="invalid"
     run_conmon_with_log_opts --log-path "k8s-file:$LOG_PATH" --log-path "$invalid_log_driver:$LOG_PATH"


### PR DESCRIPTION
- Add `--no-container-partial-message` CLI option to disable CONTAINER_PARTIAL_MESSAGE=true in journald logs                                                              - This prevents splitting of long log lines into multiple journal entries
- Particularly useful for systems parsing structured logs like JSON
- Option only affects journald log driver, warns if used without journald                  

Fixes: #335