### PR TITLE
Show the code coverage in `make test-binary` output.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,6 +89,19 @@ build_task:
         - make
         - make test
 
+# Test coverage
+coverage_task:
+    # Runs within Cirrus's "community cluster"
+    container:
+        image: "${FEDORA_CONTAINER_FQIN}"
+        cpu: 1
+        memory: 4
+
+    script:
+        - dnf install -y make glib2-devel git gcc pkg-config systemd-devel libseccomp-devel gcovr
+        - cd $CIRRUS_WORKING_DIR
+        - make test-coverage
+
 
 # Verify code was fmt'ed properly
 fmt_task:

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,11 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
+# --coverage files
+*.gcno
+*.gcda
+*.gcov
+
 bin/
 
 vendor/


### PR DESCRIPTION
This commit changes the `make test-binary` to recompile the conmon with `--coverage` flag so it generates the `.gcno and `.gcda` (these files are included in the `.gitignore` now) while running the tests.

After that, the `gcovr` is executed to show the code coverage based on those files.