### PR TITLE
Switch tests from busybox to UBI10 and add consistent terminal size v…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -84,7 +84,7 @@ build_task:
         disk: 200
 
     script:
-        - dnf install -y make glib2-devel git gcc pkg-config systemd-devel libseccomp-devel
+        - dnf install -y make glib2-devel git gcc pkg-config systemd-devel libseccomp-devel podman bats jq socat
         - cd $CIRRUS_WORKING_DIR
         - make
         - make test
@@ -99,7 +99,7 @@ coverage_task:
         disk: 200
 
     script:
-        - dnf install -y make glib2-devel git gcc pkg-config systemd-devel libseccomp-devel gcovr
+        - dnf install -y make glib2-devel git gcc pkg-config systemd-devel libseccomp-devel gcovr podman bats jq socat
         - cd $CIRRUS_WORKING_DIR
         - make test-coverage
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,11 +1,7 @@
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.access.redhat.com/ubi10/ubi:latest
 
-RUN sudo dnf install -y make automake gcc gcc-c++ kernel-devel glib2-devel && \
-    sudo dnf clean all && \
-    rm -rf /var/cache/dnf
-
-RUN sudo dnf update -y && \
-    sudo dnf clean all && \
+RUN dnf install -y make automake gcc gcc-c++ glib2-devel pkg-config systemd-devel libseccomp-devel && \
+    dnf clean all && \
     rm -rf /var/cache/dnf
 
 # replaces the mktemp from the tutorial as everything is temporary in a

--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -58,6 +58,7 @@ install_packages() {
         automake \
         conntrack \
         criu \
+        jq \
         libaio-dev \
         libapparmor-dev \
         libbtrfs-dev \
@@ -75,6 +76,7 @@ install_packages() {
         libtool \
         libudev-dev \
         libyajl-dev \
+        podman \
         sed \
         socat \
         uuid-dev

--- a/test/04-runtime.bats
+++ b/test/04-runtime.bats
@@ -18,7 +18,7 @@ teardown() {
     # Check that log file was created
     [ -f "$LOG_PATH" ]
     run cat "$LOG_PATH"
-    assert "${output}" =~ "hello from busybox"  "'hello from busybox' found in the log"
+    assert "${output}" =~ "hello from ubi10"  "'hello from ubi10' found in the log"
 }
 
 @test "runtime: container execution with different log drivers" {
@@ -26,7 +26,7 @@ teardown() {
     run_conmon_with_default_args --log-path "journald:"
 
     run journalctl --user CONTAINER_ID_FULL="$CTR_ID"
-    assert "${output}" =~ "hello from busybox"  "'hello from busybox' found in the journald"
+    assert "${output}" =~ "hello from ubi10"  "'hello from ubi10' found in the journald"
 }
 
 @test "runtime: container execution with multiple log drivers" {
@@ -37,10 +37,10 @@ teardown() {
     [ -f "$LOG_PATH" ]
 
     run cat "$LOG_PATH"
-    assert "${output}" =~ "hello from busybox"  "'hello from busybox' found in the log"
+    assert "${output}" =~ "hello from ubi10"  "'hello from ubi10' found in the log"
 
     run journalctl --user CONTAINER_ID_FULL="$CTR_ID"
-    assert "${output}" =~ "hello from busybox"  "'hello from busybox' found in the journald"
+    assert "${output}" =~ "hello from ubi10"  "'hello from ubi10' found in the journald"
 }
 
 @test "runtime: container with log size limit" {
@@ -54,7 +54,7 @@ teardown() {
     [ -f "$LOG_PATH" ]
 
     run cat "$LOG_PATH"
-    assert "${output}" !~ "hello from busybox 11"  "'hello from busybox 11' not in the logs"
+    assert "${output}" !~ "hello from ubi10 11"  "'hello from ubi10 11' not in the logs"
 }
 
 @test "runtime: invalid runtime binary should fail" {

--- a/test/06-exec-exit-status.bats
+++ b/test/06-exec-exit-status.bats
@@ -50,7 +50,7 @@ teardown() {
     fi
 
     # Check if we can create a simple container for testing
-    if ! timeout 10 podman --conmon $conmon_path run --rm busybox:latest true >/dev/null 2>&1; then
+    if ! timeout 10 podman --conmon $conmon_path run --rm registry.access.redhat.com/ubi10/ubi-micro:latest true >/dev/null 2>&1; then
         skip "Cannot create test containers with podman"
     fi
 
@@ -58,7 +58,7 @@ teardown() {
 
     # Create a test container
     local container_id
-    container_id=$(podman --conmon $conmon_path run -dt busybox:latest sleep 30)
+    container_id=$(podman --conmon $conmon_path run -dt registry.access.redhat.com/ubi10/ubi-micro:latest sleep 30)
 
     if [ -z "$container_id" ]; then
         skip "Failed to create test container"

--- a/test/07-attach.bats
+++ b/test/07-attach.bats
@@ -5,7 +5,7 @@ load test_helper
 setup() {
     check_conmon_binary
     check_runtime_binary
-    setup_container_env "/busybox cat && echo 'Container stopped!'"
+    setup_container_env "cat && echo 'Container stopped!'"
 }
 
 teardown() {

--- a/test/08-exec.bats
+++ b/test/08-exec.bats
@@ -5,7 +5,7 @@ load test_helper
 setup() {
     check_conmon_binary
     check_runtime_binary
-    setup_container_env "while [ ! -f /tmp/test.txt ]; do /busybox sleep 0.1; done; /busybox cat /tmp/test.txt"
+    setup_container_env "while [ ! -f /tmp/test.txt ]; do sleep 0.1; done; cat /tmp/test.txt"
     generate_process_spec "echo 'Hello from exec!' && echo 'Hello there!' > /tmp/test.txt"
 }
 

--- a/test/09-partial-log-test.bats
+++ b/test/09-partial-log-test.bats
@@ -14,7 +14,7 @@ teardown() {
 
 @test "partial log: container with printf (no newline) generates F-sequence" {
     # Modify config to run printf instead of echo
-    jq '.process.args = ["/busybox", "printf", "hello world"]' "$BUNDLE_PATH/config.json" > "$BUNDLE_PATH/config.json.tmp"
+    jq '.process.args = ["/usr/bin/printf", "hello world"]' "$BUNDLE_PATH/config.json" > "$BUNDLE_PATH/config.json.tmp"
     mv "$BUNDLE_PATH/config.json.tmp" "$BUNDLE_PATH/config.json"
 
     # Run conmon

--- a/test/10-ctrl.bats
+++ b/test/10-ctrl.bats
@@ -5,7 +5,7 @@ load test_helper
 setup() {
     check_conmon_binary
     check_runtime_binary
-    setup_container_env "while [ ! -f /tmp/test.txt ]; do /busybox sleep 0.1; done; /busybox stty size" "true"
+    setup_container_env "while [ ! -f /tmp/test.txt ]; do sleep 0.1; done; stty size" "true"
     generate_process_spec "echo 'Hello from exec!' && echo 'Hello there!' > /tmp/test.txt"
 }
 
@@ -38,8 +38,9 @@ test_resize_command_fail() {
     # Check that the main process noticed the /tmp/test.txt.
     assert_file_exists "$LOG_PATH"
     run cat "$LOG_PATH"
-    # No terminal resize
-    assert "${output}" =~ "standard input"
+    # No terminal resize - should show default/initial size (0 0)
+    # When resize fails, terminal stays at initial size
+    assert "${output}" =~ "0 0"
 }
 
 # Helper function to send the resize command. Fails if the resize command
@@ -102,8 +103,8 @@ test_resize_command_ok() {
     # Check that the log exists now.
     assert_file_exists "$LOG_PATH"
     run cat "$LOG_PATH"
-    # No terminal resize
-    assert "${output}" =~ "standard input"
+    # No terminal resize - should show default/initial size (0 0)
+    assert "${output}" =~ "0 0"
 }
 
 @test "ctrl: unknown message 'foo'" {
@@ -126,16 +127,33 @@ test_resize_command_ok() {
     test_resize_command_fail "1 0x10 0x20"
 }
 
-@test "ctrl: resize overflow" {
-    test_resize_command_fail "1 1000000000000 100000000000"
+@test "ctrl: resize overflow rejected" {
+    # Test that values > 65535 are properly rejected
+    # This prevents silent wraparound bugs (100000 -> 34464)
+    test_resize_command_fail "1 100000 100000"
 }
 
 @test "ctrl: resize with leading zeros" {
     test_resize_command_ok "1 0010 0020" "10 20"
 }
 
-@test "ctrl: too big size" {
-    # This is weird, but ioctl works like that...
-    # if big number is passed, it defaults to 24x80 size.
-    test_resize_command_ok "1 65535 65535" "24 80"
+@test "ctrl: maximum valid size" {
+    # Test with maximum valid practical terminal size (1000x1000)
+    # This prevents potential DoS from applications allocating large screen buffers
+    test_resize_command_ok "1 1000 1000" "1000 1000"
+}
+
+@test "ctrl: size exceeding maximum - height too large" {
+    # Values above 1000 should be rejected
+    test_resize_command_fail "1 1001 1000"
+}
+
+@test "ctrl: size exceeding maximum - width too large" {
+    # Values above 1000 should be rejected
+    test_resize_command_fail "1 1000 1001"
+}
+
+@test "ctrl: size exceeding maximum - both too large" {
+    # Values above 1000 should be rejected
+    test_resize_command_fail "1 65535 65535"
 }


### PR DESCRIPTION
…alidation

- Update Containerfile to use UBI10 base image instead of busybox
- Replace busybox references with UBI10 commands in all test files
- Add upper bound validation (1000) for terminal window size in ctrl.c to prevent wraparound bugs
- Update CI/CD dependencies to include podman, bats, jq, and socat
- Fix test assertions to expect proper terminal size behavior

Fixes: #610