### PR TITLE
Remove need for extra bytes for remote consoles

### DIFF
--- a/src/conn_sock.h
+++ b/src/conn_sock.h
@@ -3,6 +3,7 @@
 
 #include <glib.h>   /* gboolean */
 #include "config.h" /* CONN_SOCK_BUF_SIZE */
+#include "utils.h"  /* stdpipe_t */
 
 #define SOCK_TYPE_CONSOLE 1
 #define SOCK_TYPE_NOTIFY 2
@@ -52,7 +53,7 @@ char *setup_seccomp_socket(const char *socket);
 char *setup_attach_socket(void);
 void setup_notify_socket(char *);
 void schedule_main_stdin_write();
-void write_back_to_remote_consoles(char *buf, int len);
+void write_back_to_remote_consoles(stdpipe_t pipe, char *buf, size_t buflen);
 void close_all_readers();
 
 #endif // CONN_SOCK_H

--- a/src/ctr_stdio.c
+++ b/src/ctr_stdio.c
@@ -112,12 +112,7 @@ static void drain_log_buffers(stdpipe_t pipe)
 
 static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof)
 {
-	/* We use two extra bytes. One at the start, which we don't read into, instead
-	   we use that for marking the pipe when we write to the attached socket.
-	   One at the end to guarantee a null-terminated buffer for journald logging*/
-
-	char real_buf[STDIO_BUF_SIZE + 2];
-	char *buf = real_buf + 1;
+	char buf[STDIO_BUF_SIZE];
 	ssize_t num_read = 0;
 
 	if (eof)
@@ -143,15 +138,11 @@ static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof)
 		nwarnf("stdio_input read failed: %m");
 		return false;
 	} else {
-		// Always null terminate the buffer, just in case.
-		buf[num_read] = '\0';
-
 		bool written = write_to_logs(pipe, buf, num_read);
 		if (!written)
 			return false;
 
-		real_buf[0] = pipe;
-		write_back_to_remote_consoles(real_buf, num_read + 1);
+		write_back_to_remote_consoles(pipe, buf, num_read);
 		return true;
 	}
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -255,7 +255,13 @@ static inline void hashtable_free_cleanup(GHashTable **tbl)
 #define _cleanup_gerror_ _cleanup_(gerror_free_cleanup)
 
 
-ssize_t write_all(int fd, const void *buf, size_t count);
+ssize_t write_all(int fd, const void *buf, size_t buflen);
+typedef struct {
+	size_t iovcnt;
+	size_t max_iovcnt;
+	struct iovec *iov;
+} writev_iov_t;
+ssize_t writev_all(int fd, writev_iov_t *iov);
 
 int set_subreaper(gboolean enabled);
 


### PR DESCRIPTION
We use `writev()` for remote consoles to remove the need for extra bytes surrounding the data to be written.

We really don't want to "leak" the protocol requirement for remote consoles to the rest of the code base.  To hide that, and avoid two `write_all()` method calls in a row, we promote `writev_buffer_flush()` to a `utils` method called `writev_all()` to leverage I/O vectors in one call (memory copies will need to occur for remote sockets, so using `writev()` avoids that).

Further, we use the `g_ptr_array_foreach()` method instead of doing it ourselves to avoid breaking the `GPtrArray` encapsulation.

Signed-off-by: Peter Portante <peter.portante@redhat.com>

----

FWIW, this PR is a pre-requisite to #615, which in turn will make it easier to finally implement #264.