### PR TITLE
Use the actual pipe size instead of 8,192

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ docs:
 .PHONY: clean
 clean:
 	rm -rf bin/ src/*.o src/*.gcno src/*.gcda *.gcov
+	$(MAKE) -C test clean
 	$(MAKE) -C docs clean
 
 .PHONY: install install.bin install.crio install.podman podman crio

--- a/src/config.h
+++ b/src/config.h
@@ -3,7 +3,7 @@
 #define CONFIG_H
 
 #define BUF_SIZE 8192
-#define STDIO_BUF_SIZE 8192
+#define DEF_STDOUT_BUF_SIZE 65536
 #define CONN_SOCK_BUF_SIZE 32768
 #define DEFAULT_SOCKET_PATH "/var/run/crio"
 #define WIN_RESIZE_EVENT 1

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -165,6 +165,10 @@ int main(int argc, char *argv[])
 				pexit("Failed to create !terminal stdin pipe");
 
 			mainfd_stdin = fds[1];
+			ret = fcntl(mainfd_stdin, F_GETPIPE_SZ);
+			if (ret < 0)
+				pexit("main stdin pipe size determination failed");
+			mainfd_stdin_size = (size_t)ret;
 			workerfd_stdin = fds[0];
 
 			if (g_unix_set_fd_nonblocking(mainfd_stdin, TRUE, NULL) == FALSE)
@@ -175,6 +179,10 @@ int main(int argc, char *argv[])
 			pexit("Failed to create !terminal stdout pipe");
 
 		mainfd_stdout = fds[0];
+		ret = fcntl(mainfd_stdout, F_GETPIPE_SZ);
+		if (ret < 0)
+			pexit("main stdout pipe size determination failed");
+		mainfd_stdout_size = (size_t)ret;
 		workerfd_stdout = fds[1];
 	}
 
@@ -194,6 +202,13 @@ int main(int argc, char *argv[])
 		pexit("Failed to create stderr pipe");
 
 	mainfd_stderr = fds[0];
+	ret = fcntl(mainfd_stderr, F_GETPIPE_SZ);
+	if (ret < 0)
+		pexit("main stderr pipe size determination failed");
+	mainfd_stderr_size = (size_t)ret;
+	if ((mainfd_stdout >= 0) && (mainfd_stderr_size != mainfd_stdout_size)) {
+		nwarn("main stderr and stdout pipe sizes don't match");
+	}
 	workerfd_stderr = fds[1];
 
 	GPtrArray *runtime_argv = configure_runtime_args(csname);

--- a/src/conmon.c
+++ b/src/conmon.c
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 	umask(DEFAULT_UMASK);
 	_cleanup_gerror_ GError *err = NULL;
 	char buf[BUF_SIZE];
-	int num_read;
+	ssize_t num_read;
 	_cleanup_close_ int dev_null_r_cleanup = -1;
 	_cleanup_close_ int dev_null_w_cleanup = -1;
 	_cleanup_close_ int dummyfd = -1;
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
 		/* Block for an initial write to the start pipe before
 		   spawning any children or exiting, to ensure the
 		   parent can put us in the right cgroup. */
-		num_read = read(start_pipe_fd, buf, BUF_SIZE);
+		num_read = read(start_pipe_fd, buf, sizeof(buf));
 		if (num_read < 0) {
 			pexit("start-pipe read failed");
 		}
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
 		if (opt_attach) {
 			if (start_pipe_fd > 0) {
 				ndebug("exec with attach is waiting for start message from parent");
-				num_read = read(start_pipe_fd, buf, BUF_SIZE);
+				num_read = read(start_pipe_fd, buf, sizeof(buf));
 				if (num_read < 0) {
 					_pexit("start-pipe read failed");
 				}
@@ -370,7 +370,7 @@ int main(int argc, char *argv[])
 		 * Read from container stderr for any error and send it to parent
 		 * We send -1 as pid to signal to parent that create container has failed.
 		 */
-		num_read = read(mainfd_stderr, buf, BUF_SIZE - 1);
+		num_read = read(mainfd_stderr, buf, sizeof(buf) - 1);
 		const char *error_msg = NULL;
 		if (num_read > 0) {
 			buf[num_read] = '\0';

--- a/src/conn_sock.h
+++ b/src/conn_sock.h
@@ -3,6 +3,7 @@
 
 #include <glib.h>   /* gboolean */
 #include "config.h" /* CONN_SOCK_BUF_SIZE */
+#include "utils.h"  /* stdpipe_t */
 
 #define SOCK_TYPE_CONSOLE 1
 #define SOCK_TYPE_NOTIFY 2
@@ -52,7 +53,7 @@ char *setup_seccomp_socket(const char *socket);
 char *setup_attach_socket(void);
 void setup_notify_socket(char *);
 void schedule_main_stdin_write();
-void write_back_to_remote_consoles(char *buf, int len);
+void write_back_to_remote_consoles(stdpipe_t pipe, char *buf, size_t buflen);
 void close_all_readers();
 
 #endif // CONN_SOCK_H

--- a/src/ctr_logging.h
+++ b/src/ctr_logging.h
@@ -6,7 +6,7 @@
 #include <stdbool.h> /* bool */
 
 void reopen_log_files(void);
-bool write_to_logs(stdpipe_t pipe, char *buf, ssize_t num_read);
+bool write_to_logs(stdpipe_t pipe, char *buf, size_t buflen);
 void configure_log_drivers(gchar **log_drivers, int64_t log_size_max_, int64_t log_global_size_max_, char *cuuid_, char *name_, char *tag,
 			   gchar **labels);
 void sync_logs(void);

--- a/src/ctr_stdio.c
+++ b/src/ctr_stdio.c
@@ -138,11 +138,11 @@ static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof)
 		nwarnf("stdio_input read failed: %m");
 		return false;
 	} else {
-		bool written = write_to_logs(pipe, buf, num_read);
+		bool written = write_to_logs(pipe, buf, (size_t)num_read);
 		if (!written)
 			return false;
 
-		write_back_to_remote_consoles(pipe, buf, num_read);
+		write_back_to_remote_consoles(pipe, buf, (size_t)num_read);
 		return true;
 	}
 }

--- a/src/ctr_stdio.c
+++ b/src/ctr_stdio.c
@@ -112,12 +112,7 @@ static void drain_log_buffers(stdpipe_t pipe)
 
 static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof)
 {
-	/* We use two extra bytes. One at the start, which we don't read into, instead
-	   we use that for marking the pipe when we write to the attached socket.
-	   One at the end to guarantee a null-terminated buffer for journald logging*/
-
-	char real_buf[STDIO_BUF_SIZE + 2];
-	char *buf = real_buf + 1;
+	char buf[STDIO_BUF_SIZE];
 	ssize_t num_read = 0;
 
 	if (eof)
@@ -143,15 +138,11 @@ static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof)
 		nwarnf("stdio_input read failed: %m");
 		return false;
 	} else {
-		// Always null terminate the buffer, just in case.
-		buf[num_read] = '\0';
-
 		bool written = write_to_logs(pipe, buf, num_read);
 		if (!written)
 			return false;
 
-		real_buf[0] = pipe;
-		write_back_to_remote_consoles(real_buf, num_read + 1);
+		write_back_to_remote_consoles(pipe, buf, num_read);
 		return true;
 	}
 }

--- a/src/ctr_stdio.c
+++ b/src/ctr_stdio.c
@@ -112,13 +112,14 @@ static void drain_log_buffers(stdpipe_t pipe)
 
 static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof)
 {
-	char buf[STDIO_BUF_SIZE];
+	size_t buf_size = ((pipe == STDOUT_PIPE) ? mainfd_stdout_size : mainfd_stderr_size);
+	char *buf = alloca(buf_size);
 	ssize_t num_read = 0;
 
 	if (eof)
 		*eof = false;
 
-	num_read = read(fd, buf, STDIO_BUF_SIZE);
+	num_read = read(fd, buf, buf_size);
 	if (num_read == 0) {
 		if (eof)
 			*eof = true;

--- a/src/ctrl.c
+++ b/src/ctrl.c
@@ -72,6 +72,18 @@ exit:
 	mainfd_stdout = dup(console.fd);
 	if (mainfd_stdout < 0)
 		pexit("Failed to dup console file descriptor");
+	struct stat stat_s = {0};
+	int ret = fstat(mainfd_stdout, &stat_s);
+	if (ret < 0)
+		pexit("main stdout pipe fstat() failed");
+	if (S_ISFIFO(stat_s.st_mode)) {
+		ret = fcntl(mainfd_stdout, F_GETPIPE_SZ);
+		if (ret < 0)
+			pexit("main stdout pipe size determination failed");
+		mainfd_stdout_size = (size_t)ret;
+	} else {
+		mainfd_stdout_size = DEF_STDOUT_BUF_SIZE;
+	}
 
 	/* Now that we have a fd to the tty, make sure we handle any pending data
 	 * that was already buffered. */

--- a/src/globals.c
+++ b/src/globals.c
@@ -4,8 +4,11 @@ int runtime_status = -1;
 int container_status = -1;
 
 int mainfd_stdin = -1;
+size_t mainfd_stdin_size = 0;
 int mainfd_stdout = -1;
+size_t mainfd_stdout_size = 0;
 int mainfd_stderr = -1;
+size_t mainfd_stderr_size = 0;
 
 int attach_socket_fd = -1;
 int console_socket_fd = -1;

--- a/src/globals.h
+++ b/src/globals.h
@@ -8,8 +8,11 @@ extern int runtime_status;
 extern int container_status;
 
 extern int mainfd_stdin;
+extern size_t mainfd_stdin_size;
 extern int mainfd_stdout;
+extern size_t mainfd_stdout_size;
 extern int mainfd_stderr;
+extern size_t mainfd_stderr_size;
 
 extern int attach_socket_fd;
 extern int console_socket_fd;

--- a/src/utils.h
+++ b/src/utils.h
@@ -255,7 +255,13 @@ static inline void hashtable_free_cleanup(GHashTable **tbl)
 #define _cleanup_gerror_ _cleanup_(gerror_free_cleanup)
 
 
-ssize_t write_all(int fd, const void *buf, size_t count);
+ssize_t write_all(int fd, const void *buf, size_t buflen);
+typedef struct {
+	size_t iovcnt;
+	size_t max_iovcnt;
+	struct iovec *iov;
+} writev_iov_t;
+ssize_t writev_all(int fd, writev_iov_t *iov);
 
 int set_subreaper(gboolean enabled);
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,3 @@
+.PHONY: clean
+clean:
+	rm -rf /tmp/conmon-test-* /tmp/conmon-term.*

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -25,8 +25,8 @@ RUNTIME_BINARY="${RUNTIME_BINARY:-/usr/bin/runc}"
 
 # UBI10-micro container image for test rootfs
 UBI10_MICRO_IMAGE="registry.access.redhat.com/ubi10/ubi-micro:latest"
-ROOTFS_CACHE_DIR="/tmp/conmon-test-images"
-ROOTFS_CACHE_MARKER="/tmp/conmon-test-images/.ubi10-micro-cached"
+ROOTFS_CACHE_DIR="/tmp/conmon-images"
+ROOTFS_CACHE_MARKER="/tmp/conmon-images/.ubi10-micro-cached"
 VALID_PATH="/tmp"
 INVALID_PATH="/not/a/path"
 


### PR DESCRIPTION
The default for linux pipes is typically something much larger than 8,192 bytes.
We take advantage of this to fact to avoid multiple rounds of reading from a
full pipe.

The constant, `STDIO_BUF_SIZE` is removed in favor of `fcntl(F_GETPIPE_SZ)`
calls for pipes / fifos, an adding `DEF_STDIO_BUF_SIZE` for the case where
`stdout` is not a PIPE (perhaps character special file) using a 64K buffer to
consume more data per system when possible.

Signed-off-by: Peter Portante <peter.portante@redhat.com>

----

The goal of this work is to make it much easier to implement #264.