### PR TITLE
Add an easy cleanup for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ docs:
 .PHONY: clean
 clean:
 	rm -rf bin/ src/*.o src/*.gcno src/*.gcda *.gcov
+	$(MAKE) -C test clean
 	$(MAKE) -C docs clean
 
 .PHONY: install install.bin install.crio install.podman podman crio

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,4 @@
+.PHONY: clean
+clean:
+	-chmod -R 700 /tmp/conmon-test-*
+	rm -rf /tmp/conmon-test-* /tmp/conmon-term.*


### PR DESCRIPTION
The `make clean` target now cleans up the `/tmp` area a bit.  It leaves around the cache of the `busybox` image to avoid fetching it too often.