### PR TITLE
tests: Ensure necessary dependencies are available

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -61,8 +61,12 @@ log_error() {
 check_dependencies() {
     local missing_deps=()
 
-    if ! command -v bats >/dev/null 2>&1; then
+    if ! command -v bats >& /dev/null; then
         missing_deps+=("bats")
+    fi
+
+    if ! command -v socat >& /dev/null; then
+        missing_deps+=("socat")
     fi
 
     if [[ ! -x "$CONMON_BINARY" ]]; then


### PR DESCRIPTION
While most of the runtime dependencies of the test harness were being checked, `socat(1)` had been overlooked. Incorporate a dependency check into the `run-tests` script for it so that the tests don't just mysteriously fail without first indicating that `socat` is required (in the same way as is done with `runc(8)` and others)