### PR TITLE
Skip test if RUNTIME_BINARY is not runc

### DIFF
--- a/test/04-runtime.bats
+++ b/test/04-runtime.bats
@@ -92,7 +92,10 @@ teardown() {
     assert "${output}" =~ "\"pid\": $CONTAINER_PID"
 }
 
-@test "runtime: runtime error with _OCI_SYNCPIPE defined" {
+@test "runtime: runc error with _OCI_SYNCPIPE defined" {
+    if [[ $(basename "$RUNTIME_BINARY") != "runc" ]]; then
+        skip "test requires runc"
+    fi
     # This trailing " results in wrong config.json. We expect the runtime
     # failure.
     setup_container_env '"'


### PR DESCRIPTION
Skip test if RUNTIME_BINARY is not runc.

We run these tests also with crun and this one was designed for runc and fails with:

```
#/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
#|     FAIL: [no test name given]
#| expected: =~ runc create failed
#|   actual:    \{\"pid\": -1\, \"message\": \"load \`config.json\`: cannot parse the data: lexical error: invalid character inside string.\\n                                        \{     \\\"ociVersion\\\": \\\"1.0.0\\\"\,  \\n                     \(right here\) ------\^\\n\\n\"\}
#\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

https://openqa-assets.opensuse.org/tests/5644472/file/conmon-conmon-runc-user.tap.txt