### PR TITLE
Fix k8s-file log format for terminating F-sequence

### DIFF
--- a/src/ctr_logging.c
+++ b/src/ctr_logging.c
@@ -510,14 +510,14 @@ static int write_k8s_log(stdpipe_t pipe, const char *buf, ssize_t buflen)
 
 		if (writev_buffer_append_segment(k8s_log_fd, &bufv, tsbuf, TSBUFLEN - 1) >= 0) {
 			timestamp_written = true;
-			if (writev_buffer_append_segment(k8s_log_fd, &bufv, "F\n", 2) >= 0) {
+			if (writev_buffer_append_segment(k8s_log_fd, &bufv, "F \n", 3) >= 0) {
 				f_sequence_written = true;
 			}
 		}
 
 		if (timestamp_written && f_sequence_written) {
-			k8s_bytes_written += TSBUFLEN - 1 + 2;
-			k8s_total_bytes_written += TSBUFLEN - 1 + 2;
+			k8s_bytes_written += TSBUFLEN - 1 + 3;
+			k8s_total_bytes_written += TSBUFLEN - 1 + 3;
 		} else {
 			if (!timestamp_written) {
 				nwarn("failed to write timestamp for terminating F-sequence");

--- a/test/09-partial-log-test.bats
+++ b/test/09-partial-log-test.bats
@@ -80,7 +80,7 @@ teardown() {
             return 1
         }
 
-        echo "$log_content" | grep -q "stdout F$" || {
+        echo "$log_content" | grep -q "stdout F $" || {
             echo "Expected F-sequence not found"
             return 1
         }
@@ -133,7 +133,7 @@ teardown() {
 
     # For normal output with newlines, should NOT have standalone F-sequences
     # (F-sequences should only appear for partial line termination)
-    ! echo "$log_content" | grep -q "stdout F$" || {
+    ! echo "$log_content" | grep -q "stdout F $" || {
         echo "Unexpected standalone F-sequence found for normal output"
         return 1
     }


### PR DESCRIPTION
The k8s-file format requires the space separator between tag and content to be present even when content is empty. The terminating F-sequence generated for partial log lines was missing this mandatory space, causing podman logs to fail with "is not a valid container log line".

Changed terminating F-sequence from "F\n" to "F \n" and updated byte counts accordingly. Fixed test assertions to validate the correct format.

Fixes containers/podman#28014