### PR TITLE
seccomp: fix inverted notify socket setup logic

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -180,11 +180,11 @@ int main(int argc, char *argv[])
 
 	if (opt_seccomp_notify_socket != NULL) {
 #ifdef USE_SECCOMP
-		pexit("seccomp support not present");
-#else
 		if (opt_seccomp_notify_plugins == NULL)
 			pexit("seccomp notify socket specified without any plugin");
 		seccomp_listener = setup_seccomp_socket(opt_seccomp_notify_socket);
+#else
+		pexit("seccomp support not present");
 #endif
 	}
 


### PR DESCRIPTION
In 3a8c9138c84f391e5bc1a544230a2b766d50643c, the conditional in src/conmon.c was inadvertently reversed when the syntax was changed.

https://github.com/containers/conmon/commit/3a8c9138c84f391e5bc1a544230a2b766d50643c#diff-737dc81597d3e3189077545b4907aae69cce646d12b5bc5938cfdd707882bd31R181

```diff
diff --git a/src/conmon.c b/src/conmon.c
index 795701c68f754cee5d22422e12872ca24748472a..7dd1f0b560c0e593dc289f42e35931554dcb7fd9 100644
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (opt_seccomp_notify_socket != NULL) {
-#if !USE_SECCOMP
+#ifdef USE_SECCOMP
 		pexit("seccomp support not present");
 #else
 		if (opt_seccomp_notify_plugins == NULL)
```