### PR TITLE
Reset create_pid after waitpid to prevent signaling unrelated processes

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -368,6 +368,7 @@ int main(int argc, char *argv[])
 			}
 			pexitf("Failed to wait for `runtime %s`", opt_exec ? "exec" : "create");
 		}
+		create_pid = -1;
 	}
 
 	/* For exec operations, a non-zero runtime exit status reflects the exit status of the exec'd command,


### PR DESCRIPTION
After the synchronous waitpid(create_pid) succeeds in the non-terminal
code path, create_pid was never reset to -1. If the PID was later reused
by another process, on_sig_exit() would send SIGTERM to that unrelated
process.

This was observed in OpenStack environments where restarting container
services would occasionally kill qemu-kvm instances whose PIDs happened
to match a previously reaped create_pid.

Fix: set create_pid = -1 after successful waitpid(), matching the
behavior already present in the terminal path via runtime_exit_cb().

Resolves: RHEL-178025