### PR TITLE
cli: copy cwd into opt_bundle_path instead of storing a stack pointer

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -211,7 +211,7 @@ void process_cli()
 	// for the exec session. the legacy version of exec does not need this
 	// and thus we only override an empty opt_bundle_path when we're not exec
 	if (opt_bundle_path == NULL && !opt_exec) {
-		opt_bundle_path = cwd;
+		opt_bundle_path = g_strdup(cwd);
 	}
 
 	if (opt_exit_delay < 0) {

--- a/src/ctr_logging.c
+++ b/src/ctr_logging.c
@@ -1163,6 +1163,7 @@ static void rotate_k8s_file(void)
 	int parent_fd = -1;
 	_cleanup_free_ char *temp_path = NULL;
 	_cleanup_free_ char *backup_path = NULL;
+	struct flock unlock = {.l_type = F_UNLCK, .l_whence = SEEK_SET, .l_start = 0, .l_len = 0};
 
 	int old_fd = validate_and_lock_rotation(&parent_fd);
 	if (old_fd < 0)
@@ -1178,7 +1179,6 @@ static void rotate_k8s_file(void)
 	}
 
 	/* Atomic state update */
-	struct flock unlock = {.l_type = F_UNLCK};
 	fcntl(old_fd, F_SETLK, &unlock);
 	close(old_fd);
 


### PR DESCRIPTION
Two lifetime bugs I ran into while reading through conmon. Neither is a security issue, both are cases where the code reads memory that isn't valid at that point.

### 1. `opt_bundle_path` can point at a dead stack frame

In `process_cli()`, when `--bundle` isn't given and we aren't in exec mode, we fall back to the working directory:

```c
char cwd[PATH_MAX];
if (getcwd(cwd, sizeof(cwd)) == NULL) {
        nexit("Failed to get working directory");
}
...
if (opt_bundle_path == NULL && !opt_exec) {
        opt_bundle_path = cwd;
}
```

`cwd` is an automatic buffer in `process_cli()`, but `opt_bundle_path` is a global declared at the top of `cli.c`. `process_cli()` is called from `main()` and returns, so from that moment the global points into a popped frame, and every call `main()` makes afterwards reuses those 4096 bytes.

The pointer is read long after that:

- `ctrl.c:276` builds the `winsz` and `ctl` FIFO paths from it and calls `mkfifo()`
- `conn_sock.c:320` `strdup()`s it for `--full-attach-path`
- `conn_sock.c:343` `symlink()`s it
- `runtime_args.c:38` passes it to the runtime as `--bundle`, and `:59` as `--work-path` on restore
- `cgroup.c:369` `create_oom_file()`
- `seccomp_notify.c:84` builds `config.json` from it, and `:93` hands it to the seccomp notify plugin

The tell that this is an oversight rather than intent is two lines down, where the sibling assignment copies:

```c
opt_container_pid_file = g_strdup_printf("%s/pidfile-%s", cwd, opt_cid);
```

**Who hits this:** only callers that invoke conmon without `-b`/`--bundle`. podman and CRI-O both always pass it, so neither is affected. It's reachable by direct invocation and by other/out-of-tree callers. Calling it robustness rather than a vulnerability.

Whether it actually misbehaves depends on frame layout, so in practice it often reads fine today. It's still undefined behaviour and it's one intervening call away from producing a `mkfifo`/`symlink` path assembled from stale bytes.

I reduced the shape (`cli.c` globals + `cwd`, `process_cli()` returning, then `g_build_filename()` as in `ctrl.c:276`) and ASan flags it:

```
==38==ERROR: AddressSanitizer: stack-use-after-return on address 0xffffacc00020
READ of size 1 at 0xffffacc00020 thread T0
    #1 g_build_path_va
    #2 g_build_filename
    #3 main uas.c:30
Address is located in stack of thread T0 at offset 32 in frame
    #0 process_cli uas.c:9
  This frame has 1 object(s):
    [32, 4128) 'cwd' (line 10) <== Memory access is inside this variable
```

Fix is `g_strdup(cwd)`. `opt_bundle_path` is never freed anywhere in `src/`, and when `--bundle` is passed the glib option parser already gives us heap memory, so this doesn't add a double free.

### 2. `goto` jumps over the `struct flock` initializer in `rotate_k8s_file()`

Both `goto cleanup` sites in `rotate_k8s_file()` jump over

```c
struct flock unlock = {.l_type = F_UNLCK};
```

so on those two paths the initializer never runs. `cleanup:` then sets `l_type` but `l_whence`, `l_start` and `l_len` are still indeterminate when the struct goes to `F_SETLK` - and those three are what decide which range gets unlocked.

`gcc -Wjump-misses-init` points at both jumps:

```
src/ctr_logging.c:1173:17: warning: jump skips variable initialization [-Wjump-misses-init]
 1173 |                 goto cleanup;
src/ctr_logging.c:1190:1: note: label 'cleanup' defined here
src/ctr_logging.c:1181:22: note: 'unlock' declared here
```

Moved the declaration up with the other locals and spelled out the whole-file range. The warning is gone after the change. I left the existing `unlock.l_type = F_UNLCK;` at `cleanup:` alone since it's harmless.

### Build status

Built on Fedora 41 with the repo Makefile (glib2, libseccomp, systemd headers; `USE_JOURNALD=1`, `USE_SECCOMP=1`), clean under the existing `-Wall -Wextra -Werror`. `make fmt` produces no changes beyond the two edits.

Being straight about what I did not do: I don't have a Linux box set up to run the bats suite against a real runtime, so I have not exercised these paths end to end in a live container. The use-after-scope repro above is a reduced harness, not the conmon binary. Happy to split this into two PRs if you'd rather review them separately.
