### PR TITLE
oom: terminate the oom_score_adj buffer before parsing it

### DIFF
--- a/src/oom.c
+++ b/src/oom.c
@@ -19,9 +19,12 @@ static void write_oom_adjust(int oom_score, int *old_value)
 		return;
 	}
 	if (old_value) {
-		if (read(oom_score_fd, fmt_oom_score, sizeof(fmt_oom_score)) < 0) {
+		ssize_t nread = read(oom_score_fd, fmt_oom_score, sizeof(fmt_oom_score) - 1);
+		if (nread < 0) {
 			ndebugf("failed to read from /proc/self/oom_score_adj: %m");
+			nread = 0;
 		}
+		fmt_oom_score[nread] = '\0';
 		*old_value = atoi(fmt_oom_score);
 	}
 	snprintf(fmt_oom_score, sizeof(fmt_oom_score), "%d", oom_score);


### PR DESCRIPTION
`write_oom_adjust()` reads `/proc/self/oom_score_adj` into a 16 byte stack buffer and only tests the `read()` result for failure. The count itself is thrown away, so the buffer is never NUL terminated and `atoi()` keeps scanning past whatever was stored.

Two things fall out of that:

- If `read()` fails, the buffer is never written at all. The code logs at debug level and then still runs `atoi()` over indeterminate stack, so `old_oom_score` picks up whatever was there. `reset_oom_adjust()` later writes that value back to `oom_score_adj`.
- If the read fills all 16 bytes with no NUL, `atoi()` reads past the end of the buffer.

The fix reads at most `sizeof(buf) - 1`, terminates at the returned length, and falls back to an empty string on failure so `old_value` stays 0, which is what `old_oom_score` is declared as anyway.

In practice the kernel only ever puts something like `-1000\n` in that file, so the out of bounds read is not reachable with real content today. This is a robustness fix, not a security one. The unterminated-buffer-after-failed-read case is the one that can actually bite.

On the reachability question: `attempt_oom_adjust(-1000)` runs from `main()` on every conmon start, and it is the only thing that populates `old_oom_score`.

### What I verified

I could not build conmon on this machine. It is Linux only and `make` fails on macOS before it reaches anything I touched:

```
src/conmon.c:165:8: error: call to undeclared function 'pipe2'
```

That failure is pre-existing and unrelated to this change. I don't have a Linux box or a container runtime here, so **I have not run the test suite and I am not claiming a green build.** CI will be the real check.

What I could do:

- `src/oom.c` compiles clean on its own with the project's `-std=c99 -Os -Wall -Wextra -Werror`, though the `__linux__` body is excluded on macOS so that only covers syntax.
- I pulled the old and new bodies into a standalone harness and ran the 16 byte no-NUL case under ASan. The current code trips it, the patched version doesn't:

```
==56887==ERROR: AddressSanitizer: stack-buffer-overflow
READ of size 17 at 0x00016fdb2910 thread T0
    #0 atoi
    #1 before h3.c:8
```

- Same harness with normal content (`-998\n`) gives the same result before and after, so the ordinary path is unchanged.

I also tried to get the failed-`read()` path to produce a visibly wrong number by dirtying the stack frame first, and it kept coming back 0 on this compiler. So I'm calling that one reasoned from the source rather than reproduced.

This is separate from #664 and touches a different file.
