### PR TITLE
Restrict targets to golang supported architectures

### DIFF
--- a/rpm/conmon.spec
+++ b/rpm/conmon.spec
@@ -26,6 +26,10 @@ Summary: OCI container runtime monitor
 URL: https://github.com/containers/%{name}
 # Tarball fetched from upstream
 Source0: %{url}/archive/v%{version}.tar.gz
+
+# available only on golang supported arches
+ExclusiveArch: %{golang_arches_future}
+
 %if %{with docs}
 BuildRequires: go-md2man
 %endif


### PR DESCRIPTION
- Build only on architectures listed in %{golang_arches_future}
- Resolves FTBFS on i686 - https://bugzilla.redhat.com/show_bug.cgi?id=2503825