### PR TITLE
test: don't let a failed image pull look like a passing test run

### DIFF
--- a/test/06-exec-exit-status.bats
+++ b/test/06-exec-exit-status.bats
@@ -46,22 +46,23 @@ teardown() {
     local conmon_path="$(dirname "$CONMON_BINARY")/conmon"
 
     if [ ! -f "$conmon_path" ]; then
-        skip "conmon binary not found for integration testing at $conmon_path"
+        die "conmon binary not found for integration testing at $conmon_path"
     fi
 
-    # Check if we can create a simple container for testing
-    if ! timeout 10 podman --conmon $conmon_path run --rm registry.access.redhat.com/ubi10/ubi-micro:latest true >/dev/null 2>&1; then
-        skip "Cannot create test containers with podman"
+    # Check if we can create a simple container for testing.
+    run timeout 10 podman --conmon $conmon_path run --rm "$UBI10_MICRO_IMAGE" true
+    if [ "$status" -ne 0 ]; then
+        die "cannot create test containers with podman: $output"
     fi
 
     echo "Running integration test with podman..."
 
     # Create a test container
     local container_id
-    container_id=$(podman --conmon $conmon_path run -dt registry.access.redhat.com/ubi10/ubi-micro:latest sleep 30)
+    container_id=$(podman --conmon $conmon_path run -dt "$UBI10_MICRO_IMAGE" sleep 30)
 
     if [ -z "$container_id" ]; then
-        skip "Failed to create test container"
+        die "failed to create test container"
     fi
 
     # Test 1: Success case

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -11,6 +11,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 CONMON_BINARY="${CONMON_BINARY:-$PROJECT_ROOT/bin/conmon}"
 RUNTIME_BINARY="${RUNTIME_BINARY:-/usr/bin/runc}"
 BATS_OPTIONS="${BATS_OPTIONS:-}"
+CONMON_TEST_STRICT="${CONMON_TEST_STRICT:-}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -31,6 +32,7 @@ OPTIONS:
     -v, --verbose           Verbose output
     -t, --tap               Output in TAP format
     -j, --jobs N            Run tests in parallel with N jobs
+    -s, --strict            Treat skipped tests as failures (for CI)
     --filter PATTERN        Run only tests matching PATTERN
 
 EXAMPLES:
@@ -42,6 +44,7 @@ EXAMPLES:
 ENVIRONMENT VARIABLES:
     CONMON_BINARY          Path to conmon binary
     RUNTIME_BINARY         Path to runtime binary
+    CONMON_TEST_STRICT     Same as --strict, if set to a non-empty value
     UBI10_MICRO_IMAGE      Image to take the test rootfs from
     BATS_OPTIONS           Additional options to pass to bats
 EOF
@@ -123,6 +126,10 @@ main() {
                 filter="$2"
                 shift 2
                 ;;
+            -s|--strict)
+                CONMON_TEST_STRICT=1
+                shift
+                ;;
             *.bats)
                 test_files+=("$1")
                 shift
@@ -198,6 +205,7 @@ main() {
     # Export environment variables for tests
     export CONMON_BINARY
     export RUNTIME_BINARY
+    export CONMON_TEST_STRICT
 
     log_info "Running tests with:"
     log_info "  conmon binary: $CONMON_BINARY"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -42,6 +42,7 @@ EXAMPLES:
 ENVIRONMENT VARIABLES:
     CONMON_BINARY          Path to conmon binary
     RUNTIME_BINARY         Path to runtime binary
+    UBI10_MICRO_IMAGE      Image to take the test rootfs from
     BATS_OPTIONS           Additional options to pass to bats
 EOF
 }

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Suite-wide setup: prepare the container rootfs used by the container
+# tests exactly once.
+#
+# Doing this here rather than in each test's setup() means:
+#  - the image is pulled once per run, not once per test (which used to
+#    be dozens of registry round-trips, and racy under `bats --jobs`);
+#  - a failure to obtain the image aborts the whole run, instead of
+#    silently turning every container test into a skip (which made a
+#    broken environment look like a fully passing test suite).
+
+load test_helper
+
+# Bail out of the suite, telling the user what went wrong.
+suite_fail() {
+    echo "# FAIL: $*" >&3
+    return 1
+}
+
+setup_suite() {
+    if ! command -v podman >/dev/null 2>&1; then
+        suite_fail "podman is required to prepare the test rootfs"
+        return 1
+    fi
+
+    # Keep the rootfs as a tarball rather than an extracted tree: tests
+    # extract their own copy, which is both cheap and free of the
+    # permission problems of copying files like /etc/shadow (mode 0000)
+    # around as an unprivileged user.
+    export CONMON_TEST_ROOTFS_TAR="$BATS_SUITE_TMPDIR/rootfs.tar"
+
+    # Note the lack of output redirection here: when this fails, the
+    # reason for the failure is the whole point.
+    if ! podman pull --policy=newer "$UBI10_MICRO_IMAGE"; then
+        suite_fail "failed to pull $UBI10_MICRO_IMAGE"
+        return 1
+    fi
+
+    local ctr
+    if ! ctr=$(podman create "$UBI10_MICRO_IMAGE"); then
+        suite_fail "failed to create a container from $UBI10_MICRO_IMAGE"
+        return 1
+    fi
+    if ! podman export "$ctr" > "$CONMON_TEST_ROOTFS_TAR"; then
+        podman rm "$ctr" >/dev/null 2>&1 || true
+        suite_fail "failed to export the rootfs from $UBI10_MICRO_IMAGE"
+        return 1
+    fi
+    podman rm "$ctr" >/dev/null 2>&1 || true
+}

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -32,7 +32,9 @@ setup_suite() {
 
     # Note the lack of output redirection here: when this fails, the
     # reason for the failure is the whole point.
-    if ! podman pull --policy=newer "$UBI10_MICRO_IMAGE"; then
+    # NB: no --policy here, it is not supported by podman < 5.0 (as found
+    # on e.g. Ubuntu 24.04), and plain "podman pull" pulls anyway.
+    if ! podman pull "$UBI10_MICRO_IMAGE"; then
         suite_fail "failed to pull $UBI10_MICRO_IMAGE"
         return 1
     fi

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -23,22 +23,15 @@ assert_failure() {
 CONMON_BINARY="${CONMON_BINARY:-/usr/bin/conmon}"
 RUNTIME_BINARY="${RUNTIME_BINARY:-/usr/bin/runc}"
 
-# UBI10-micro container image for test rootfs
-UBI10_MICRO_IMAGE="registry.access.redhat.com/ubi10/ubi-micro:latest"
+# UBI10-micro container image for test rootfs. Can be overridden to use
+# a local mirror (or to test the failure path).
+UBI10_MICRO_IMAGE="${UBI10_MICRO_IMAGE:-registry.access.redhat.com/ubi10/ubi-micro:latest}"
 VALID_PATH="/tmp"
 INVALID_PATH="/not/a/path"
 
 # Generate a unique container ID for each test
 generate_ctr_id() {
     echo "conmon-test-$(date +%s)-$$-$RANDOM"
-}
-
-# Pull UBI10-micro rootfs for container tests
-pull_ubi10_rootfs() {
-    # Pull UBI10-micro image if not already present
-    if ! podman pull --policy=newer "$UBI10_MICRO_IMAGE" >/dev/null 2>&1; then
-        skip "Failed to pull UBI10-micro image"
-    fi
 }
 
 # Run conmon with given arguments and capture output
@@ -327,22 +320,13 @@ setup_container_env() {
     local use_terminal="$2"
     setup_test_env
 
-    # Pull UBI10-micro image
-    pull_ubi10_rootfs
-
-    # Create the rootfs directory
+    # The rootfs tarball is fetched once per run by setup_suite; give
+    # each test its own extracted copy.
+    if [[ ! -f "${CONMON_TEST_ROOTFS_TAR:-}" ]]; then
+        die "CONMON_TEST_ROOTFS_TAR is not set up (is setup_suite.bash in place?)"
+    fi
     mkdir -p "$ROOTFS"
-
-    # Extract UBI10-micro container filesystem to rootfs
-    local temp_container="conmon-test-ubi10-$$-$RANDOM"
-    if ! podman create --name "$temp_container" "$UBI10_MICRO_IMAGE" >/dev/null 2>&1; then
-        skip "Failed to create UBI10-micro container"
-    fi
-    if ! podman export "$temp_container" | tar -C "$ROOTFS" -xf - 2>/dev/null; then
-        podman rm "$temp_container" >/dev/null 2>&1 || true
-        skip "Failed to export UBI10-micro rootfs"
-    fi
-    podman rm "$temp_container" >/dev/null 2>&1 || true
+    tar -C "$ROOTFS" -xf "$CONMON_TEST_ROOTFS_TAR" || die "failed to extract test rootfs"
 
     # Generate OCI runtime configuration
     generate_runtime_config "$BUNDLE_PATH" "$ROOTFS" "$use_terminal" "$command"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -421,13 +421,17 @@ start_conmon_with_default_args() {
         return
     fi
 
-    # Do not start the container if it's already running. This can happen
-    # when `start_conmon_with_default_args` has already been called and this
-    # second call uses option like --exec which connects to already running
-    # container.
+    # Do not try to start the container if it has already been started. This
+    # happens when `start_conmon_with_default_args` has already been called
+    # and this second call uses an option like --exec, which connects to an
+    # already running container.
+    #
+    # Note the container may well be gone by the time we look: an exec that
+    # makes the container's main process exit is racing with us here, so
+    # "stopped" (and "paused") mean "already started", too.
     run_runtime state "$CTR_ID"
     echo "$output"
-    if expr "$output" : ".*status\": \"running"; then
+    if [[ "$output" =~ \"status\":\ *\"(running|stopped|paused)\" ]]; then
         return
     fi
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -29,6 +29,14 @@ UBI10_MICRO_IMAGE="${UBI10_MICRO_IMAGE:-registry.access.redhat.com/ubi10/ubi-mic
 VALID_PATH="/tmp"
 INVALID_PATH="/not/a/path"
 
+# In strict mode (CI), a skipped test is a failed test: a run that skips
+# everything must not be reported as a successful one.
+if [[ -n "${CONMON_TEST_STRICT:-}" ]]; then
+    skip() {
+        die "test skipped in strict mode: $*"
+    }
+fi
+
 # Generate a unique container ID for each test
 generate_ctr_id() {
     echo "conmon-test-$(date +%s)-$$-$RANDOM"


### PR DESCRIPTION
While debugging a runc CI failure ([opencontainers/runc#5399][1]) I found
that the conmon test suite can report success without having run a single
container test.

Each container test pulls the UBI10-micro image and exports its rootfs in
its own `setup()`, so a full run does dozens of registry round-trips --
all of them concurrent under `--jobs`. When the pull fails, the failure is
reported with `skip()`, so bats prints `ok`, `run-tests.sh` prints
"All tests passed!", and the job goes green.

That is exactly what happened in runc's CI: on the runs where the pull
succeeded, all 38 container tests ran and failed (for an unrelated,
environmental reason); on the runs where the pull failed, everything was
skipped and the job passed. A deterministic breakage looked like a ~50%
flake.

The three commits here:

1. Move the pull and rootfs export into `setup_suite()`, which runs once
   per run and, unlike a per-test `skip`, aborts the whole run when it
   fails. The rootfs is kept as a tarball that each test extracts into its
   own bundle, so tests stay independent. podman's output is no longer
   sent to `/dev/null` -- when obtaining the image fails, the reason is the
   whole point. `UBI10_MICRO_IMAGE` becomes overridable, for a local mirror
   or for testing this failure path.

2. Turn infrastructure failures in `06-exec-exit-status.bats` ("podman is
   here but the container could not be created") into hard failures.
   `skip()` should mean "this environment can't run this test by design",
   not "our fixture broke".

3. Add `--strict` / `CONMON_TEST_STRICT=1`, which turns every skip into a
   failure, so CI notices when tests silently stop running.

Tested locally against runc, rootless:

- full suite with `--strict -j 4`: 119/119 pass
- with `UBI10_MICRO_IMAGE=localhost/no-such-image:nope`:
  `not ok 1 setup_suite`, no tests executed, exit 1, and podman's actual
  error is printed. Before this series, the same situation was a silent
  all-green run.

[1]: https://github.com/opencontainers/runc/issues/5399