### PR TITLE
ci: fix runc build by disabling libpathrs build tag

### DIFF
--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -128,7 +128,7 @@ install_cni_plugins() {
 install_runc() {
     git clone --depth 1 --branch "${VERSIONS["runc"]}" https://github.com/opencontainers/runc
     pushd runc
-    make
+    make RUNC_BUILDTAGS=-libpathrs
     sudo install -D -m0755 runc /usr/sbin/runc
     popd
     rm -rf runc


### PR DESCRIPTION
runc v1.5.1 added `libpathrs` to its default build tags (`BUILDTAGS := seccomp urfave_cli_no_docs libpathrs`), which requires the `libpathrs` C library to be installed on the system. Since `libpathrs-dev` is not available in the Ubuntu runner environment, the CI fails at the `install_runc` step with:

```
Package pathrs was not found in the pkg-config search path.
Package 'pathrs', required by 'virtual:world', not found
make: *** [Makefile:85: runc-bin] Error 1
```

This fix passes `RUNC_BUILDTAGS=-libpathrs` to `make`, which uses runc's built-in mechanism (Makefile lines 15-19) to remove `libpathrs` from the build tags. runc falls back to a pure-Go path resolver when `libpathrs` is not enabled.

Fixes the CI failure introduced by the runc v1.4.2 to v1.5.1 bump.