### PR TITLE
ci: remove the runner image's container configuration files

### DIFF
--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -245,6 +245,11 @@ install_testdeps() {
     sudo cp test/redhat_sigstore.yaml /etc/containers/registries.d/registry.access.redhat.com.yaml
     sudo cp test/registries.conf /etc/containers/registries.conf
 
+    # Remove the container configuration files shipped by the runner image, so
+    # cri-o uses its own defaults rather than the ones tailored for the
+    # pre-installed rootless podman. Same as cri-o's install_files does.
+    sudo rm -f /usr/share/containers/containers.conf /etc/containers/storage.conf
+
     # critest has to match the cri-o version we test against, otherwise it
     # runs conformance tests for features cri-o does not implement yet, and
     # those fail. Use the very same version cri-o itself is tested with.


### PR DESCRIPTION
The GitHub runner image ships `/etc/containers/storage.conf` and
`/usr/share/containers/containers.conf` tailored for its pre-installed
rootless podman bundle, and cri-o picks those up: `crio config` bakes the
storage settings into the config generated by the test suite.

As a result, the tests run with

```
overlay.mount_program=/usr/local/bin/fuse-overlayfs
overlay.ignore_chown_errors=true
```

which consistently breaks three user namespace tests:

```
not ok 217 ctr_userns run container with drop_infra_ctr disabled
not ok 219 ctr_userns mappings persist after crio restart with drop_infra_ctr disabled
not ok 221 ctr_userns mappings persist after container kill and restart with drop_infra_ctr disabled
```

all of them failing to start the infra container:

```
level=error msg="Container creation error: mkdirat `proc`: Permission denied"
```

With a mount program set, containers/storage claims it can shift UIDs and
GIDs (`SupportsShifting` returns true unconditionally), so the layers are
neither chowned nor mounted with an idmapped mount (`needsIDMapping`
explicitly requires an empty `mountProgram`) -- but the mapping does not make
it into the fuse-overlayfs mount options either. The layers thus stay owned by
the real root, while the container's root is uid 100000 on the host, so the
runtime can't create the `/proc` mount point in the pause image rootfs (which
contains nothing but `/pause`). The variants with `drop_infra_ctr` enabled pass
because the workload image already has all the mount points, and no write to
the rootfs is needed.

Remove both files, the same way cri-o's own `scripts/github-actions-setup` does
since commit 20e962381d2c ("Update c/storage").

🤖 Generated with [Claude Code](https://claude.com/claude-code)