### PR TITLE
[test/DNM] ci: dump podman info

### DIFF
--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -28,6 +28,7 @@ main() {
     install_cni_plugins
     install_testdeps
     setup_etc_subid
+    show_podman
 }
 
 prepare_system() {
@@ -209,6 +210,32 @@ install_testdeps() {
     popd
 
     install_critools "$critools"
+}
+
+# show_podman is a temporary diagnostic: the test suite uses podman to
+# prepare the test rootfs (test/setup_suite.bash) and to run containers
+# (test/06-exec-exit-status.bats), and it looks like there are two of them
+# -- the runner image ships podman 5.x under /usr/local, while our own
+# "apt install podman" adds Ubuntu's 4.x to /usr/bin -- so it is not
+# obvious which one actually runs. Print the facts.
+show_podman() {
+    set +x
+
+    echo "=== podman binaries in PATH ==="
+    command -v -a podman || echo "none found"
+    echo "=== their versions ==="
+    for p in $(command -v -a podman); do
+        echo -n "$p: "
+        "$p" --version || true
+    done
+    echo "=== what the tests get (they run under sudo) ==="
+    sudo sh -c 'echo "PATH=$PATH"; command -v podman; podman --version' || true
+    echo "=== the runtime that podman picks ==="
+    sudo podman info --format '{{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Path}}' || true
+    echo "=== conmon binaries in PATH ==="
+    command -v -a conmon || echo "none found"
+
+    set -x
 }
 
 setup_etc_subid() {


### PR DESCRIPTION
**Do not merge** -- this is a diagnostic run, to be dropped once the numbers are in.

The test suite uses podman for real: `test/setup_suite.bash` pulls ubi10-micro and exports the test rootfs from it, and `test/06-exec-exit-status.bats` runs containers with `podman --conmon`. So which podman it gets matters.

There appear to be two on the runner:

* the `ubuntu-24.04` image readme lists **Podman 5.8.4**, which is not what noble ships in apt (`4.9.3+ds1-1ubuntu0.2`) -- and, tellingly, the same readme lists Buildah 1.33.7 and Skopeo 1.13.3, which *are* the noble versions. So podman comes from the image's own bundle, the same one under `/usr/local` that already forced us to add `remove_runtimes`;
* our own `install_packages` then installs Ubuntu's 4.9.3 into `/usr/bin`.

The setup log agrees -- installing the deb lands some units under `/usr/lib/systemd/system`, but `podman.service`, `podman.socket` and `podman-restart.service` resolve to `/usr/local/lib/systemd/system`, i.e. they were already there:

```
Created symlink .../podman-auto-update.service → /usr/lib/systemd/system/...
Created symlink .../podman.service            → /usr/local/lib/systemd/system/...
Created symlink .../podman.socket             → /usr/local/lib/systemd/system/...
```

Since `/usr/local/bin` precedes `/usr/bin` in `PATH` (and in sudo's `secure_path`), the apt podman we install is likely shadowed and never runs. That would make the `podman` entry in our apt list pure noise -- it also drags in Ubuntu's conmon, which is the last thing this repo wants lying around.

Rather than guess, this prints the facts from a real run: every podman in `PATH` with its version, what `podman` resolves to under sudo (which is how the tests run), the runtime podman picks, and the conmon binaries in `PATH`.

If it confirms the above, the follow-up is to drop `podman` from `install_packages` and keep using the image's 5.x -- which is what happens today anyway, only by accident rather than on purpose. Ubuntu's 4.9.3 is a poor thing to test conmon against: it is exactly what made `podman pull --policy` fail in 0af8e86, after months of container tests silently skipping themselves.

Deliberately *not* touched here: `remove_packages()` is defined but never called from `main()`. Calling it would remove conmon and containernetworking-plugins, and since apt's podman depends on conmon, that may well take podman with it -- a real behavior change that this diagnostic should inform, not pre-empt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)