### PR TITLE
ci, test: CI log readability, superseded runs, sync pipe race

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,13 @@ on:
   pull_request:
 permissions: {}
 
+# Cancel a PR's older runs when it is pushed to again. github.head_ref is set
+# for pull_request events only, so pushes to main and tags fall back to the
+# unique run_id and are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   coverage:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,13 @@ on:
   pull_request:
 permissions: {}
 
+# Cancel a PR's older runs when it is pushed to again. github.head_ref is set
+# for pull_request events only, so pushes to main and tags fall back to the
+# unique run_id and are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   conmon:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,13 @@ on:
   pull_request:
 permissions: {}
 
+# Cancel a PR's older runs when it is pushed to again. github.head_ref is set
+# for pull_request events only, so pushes to main and tags fall back to the
+# unique run_id and are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   lint:

--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -14,25 +14,38 @@ declare -A VERSIONS=(
 )
 
 main() {
-    set -x
     # None of the git clones below has a timeout of its own, and a stalled
     # one hangs this script until the job times out. Make git give up on a
     # connection that transfers less than 1 KiB/s for a minute.
     export GIT_HTTP_LOW_SPEED_LIMIT=1024 GIT_HTTP_LOW_SPEED_TIME=60
 
-    prepare_system
+    step prepare_system
 
-    install_packages
+    step install_packages
     # NOTE this has to run after install_packages, which may install runtimes
     # as podman dependencies.
-    remove_runtimes
-    install_conmon
-    install_bats
-    install_runc
-    install_crun
-    install_cni_plugins
-    install_testdeps
-    setup_etc_subid
+    step remove_runtimes
+    step install_conmon
+    step install_bats
+    step install_runc
+    step install_crun
+    step install_cni_plugins
+    step install_testdeps
+    step setup_etc_subid
+}
+
+# step runs the given function with its output folded into a collapsible
+# GitHub Actions log group [1], so that this script's very verbose output can
+# be navigated at all. Outside of GitHub Actions the markers are just a couple
+# of harmless extra lines.
+#
+# [1] https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#grouping-log-lines
+step() {
+    echo "::group::$1"
+    set -x
+    "$@"
+    { set +x; } 2>/dev/null
+    echo "::endgroup::"
 }
 
 prepare_system() {

--- a/test/04-runtime.bats
+++ b/test/04-runtime.bats
@@ -86,7 +86,7 @@ teardown() {
         --log-path "k8s-file:$LOG_PATH" 6>"$OCI_SYNCPIPE_PATH"
 
     # Check that the pid is sent to the sync pipe.
-    assert_file_exists $TEST_TMPDIR/syncpipe-output
+    wait_for_syncpipe_output 1
     run cat $TEST_TMPDIR/syncpipe-output
     CONTAINER_PID=$(cat "$CONTAINER_PIDFILE")
     assert_json "${output}" =~ "\"pid\": $CONTAINER_PID"
@@ -119,7 +119,7 @@ teardown() {
     wait_for_conmon_exit "$CONMON_PID"
 
     # Check that the error is sent to the sync pipe.
-    assert_file_exists $TEST_TMPDIR/syncpipe-output
+    wait_for_syncpipe_output 1
     run cat $TEST_TMPDIR/syncpipe-output
     assert_json "${output}" =~ "\"pid\": -1"
     assert_json "${output}" =~ "\"message\":"

--- a/test/08-exec.bats
+++ b/test/08-exec.bats
@@ -158,7 +158,7 @@ teardown() {
     wait_for_runtime_status "$CTR_ID" stopped
 
     # Check that the conmon wrote something back.
-    assert_file_exists $TEST_TMPDIR/syncpipe-output
+    wait_for_syncpipe_output 1
     run cat $TEST_TMPDIR/syncpipe-output
     assert_json "${output}" =~ '"exit_code": 0'
 }
@@ -179,7 +179,7 @@ teardown() {
 
     # There should be two values with "data" key. The first one is the PID and
     # the second one is the exit code.
-    assert_file_exists $TEST_TMPDIR/syncpipe-output
+    wait_for_syncpipe_output 2
     run cat $TEST_TMPDIR/syncpipe-output
     CONTAINER_PID=$(cat "$CONTAINER_PIDFILE")
     assert_json "${output}" =~ "\"data\": $CONTAINER_PID"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -88,6 +88,34 @@ check_dependencies() {
     fi
 }
 
+# Print what the tests are about to run with. The versions vary a lot --
+# across the Ubuntu 22.04/24.04/26.04 runner images, across architectures,
+# and between this repo's CI and runc's, which runs this suite as well --
+# and a failure report is worth little without them.
+show_environment() {
+    local p
+
+    log_info "Running tests with:"
+    log_info "  kernel:  $(uname -srm)"
+    if [[ -r /etc/os-release ]]; then
+        log_info "  distro:  $(. /etc/os-release && echo "$PRETTY_NAME")"
+    fi
+    log_info "  conmon:  $CONMON_BINARY: $("$CONMON_BINARY" --version 2>&1 | tr '\n' ' ' | sed 's/  *$//')"
+    log_info "  runtime: $RUNTIME_BINARY: $("$RUNTIME_BINARY" --version 2>&1 | head -1)"
+    log_info "  bats:    $(command -v bats): $(bats --version 2>&1)"
+
+    # The suite uses podman to prepare the test rootfs and to run
+    # containers, and a runner may well have more than one -- list them all,
+    # first in PATH wins.
+    if ! command -v podman >/dev/null 2>&1; then
+        log_warn "  podman:  not found, container tests will not run"
+    else
+        for p in $(type -a -P podman); do
+            log_info "  podman:  $p: $("$p" --version 2>&1)"
+        done
+    fi
+}
+
 main() {
     local verbose=false
     local tap=false
@@ -207,9 +235,7 @@ main() {
     export RUNTIME_BINARY
     export CONMON_TEST_STRICT
 
-    log_info "Running tests with:"
-    log_info "  conmon binary: $CONMON_BINARY"
-    log_info "  runtime binary: $RUNTIME_BINARY"
+    show_environment
     log_info "  test files: ${test_files[*]}"
 
     # Run the tests

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -509,6 +509,25 @@ run_conmon_with_default_args() {
     wait_for_conmon_exit "$CONMON_PID"
 }
 
+# wait_for_syncpipe_output waits until the sync pipe reader has written the
+# given number of lines. The reader runs in the background, so it lags behind
+# the conmon that wrote to the pipe, and asserting right away is a race.
+wait_for_syncpipe_output() {
+    local how_many=${1:-1}
+    local how_long=${2:-10}
+    local file="$TEST_TMPDIR/syncpipe-output"
+
+    local t1=$((SECONDS + how_long))
+    while [ "$SECONDS" -lt "$t1" ]; do
+        if [ -e "$file" ] && [ "$(wc -l <"$file")" -ge "$how_many" ]; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    die "timed out waiting for $how_many line(s) in $file: $(cat "$file" 2>&1)"
+}
+
 # Generic helper function to create pipe and read from it.
 _start_pipe_reader() {
     local pipe_path=$1


### PR DESCRIPTION
Three independent readability fixes for CI logs, plus a fix for a flaky test the first CI run of this PR ran into.

### 1. `test: print the versions the tests run with`

Which versions a run gets varies a lot -- across the Ubuntu 22.04, 24.04 and 26.04 runner images, across architectures, and between this repo's CI and runc's, which runs this suite as well. A failure report that does not say which conmon, runtime, podman and kernel were involved is worth very little.

`test/run-tests.sh` already printed the conmon and runtime *paths*; this turns that into a proper block:

```
[INFO] Running tests with:
[INFO]   kernel:  Linux 6.11.0-1018-azure x86_64
[INFO]   distro:  Ubuntu 24.04.3 LTS
[INFO]   conmon:  /home/runner/work/conmon/conmon/bin/conmon: conmon version 2.2.1 commit: ...
[INFO]   runtime: /usr/bin/runc: runc version 1.5.1
[INFO]   bats:    /usr/local/bin/bats: Bats 1.13.0
[INFO]   podman:  /usr/local/bin/podman: podman version 5.8.4
[INFO]   podman:  /usr/bin/podman: podman version 4.9.3
```

podman gets listed in full rather than just resolved, because a runner may well have more than one: the runner image ships podman 5.x under `/usr/local`, while `apt install podman` adds Ubuntu's 4.x to `/usr/bin`. First in PATH wins, and it is worth being able to see which that was -- podman 4.x vs 5.x has already cost us once, in 0af8e86 ("test: don't use podman pull --policy").

This benefits runc's CI as much as ours, since it runs this very suite.

### 2. `ci: group the setup log`

`hack/github-actions-setup` runs under `set -x` and installs a dozen things; its log is a few thousand lines of apt, git and make output in which nothing can be found. Each step now goes into a collapsible [log group](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#grouping-log-lines):

```
::group::install_crun
+ install_crun
...
::endgroup::
```

so the step that failed -- or the step that hangs, which is what prompted this -- is one click away instead of a scroll hunt. Outside GitHub Actions the markers are two harmless extra lines per step.

Verified locally: the version block renders as above, and the `step` wrapper keeps `set -x` inside the group while leaving the markers themselves untraced (they have to be plain lines for GitHub to fold them).

### 3. `ci: cancel superseded PR runs`

Pushing to a PR leaves its previous runs going. A branch pushed to a few times in a row ends up with several full runs of the same workflow competing for runners, all but the last of which nobody will look at -- and the integration workflow takes about 40 minutes.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true
```

`github.head_ref` is set for `pull_request` events only, so pushes to main and to tags fall back to the unique `run_id`, each landing in a group of its own and never being cancelled. `static.yml` is left alone: it runs on tags and `workflow_dispatch` only, where there is nothing to supersede.

### 4. `test: wait for the sync pipe output`

The first CI run of this PR hit

```
not ok 99 exec: --exec with _OCI_SYNCPIPE defined
...
FAIL: File /tmp/conmon-test-HAmjK4/syncpipe-output does not exist.
```

in the coverage job. The reader of the sync pipe runs in the background, appending to that file as the lines arrive, so it lags behind the conmon that wrote them -- and the tests checked for the file as soon as the container was reported stopped. The coverage job, the slowest of them all, loses that race often enough to matter.

The four affected tests now wait for the expected number of lines to show up instead. That also covers the `--api-version=1` test, which wants two of them (the pid and the exit status) and could previously have found the file with only the first one in it.

Unrelated to the rest of the PR, but it is what the PR's own CI failed on.
