### PR TITLE
ci: avoid downloading go; drop the cri-o oldstable job; use sudo less

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - run: sudo hack/github-actions-setup
+      - uses: actions/setup-go@v7
+        with:
+          go-version: stable
+          cache: false
+      - run: hack/github-actions-setup
       - name: Run conmon integration tests
         run: |
           sudo mkdir -p /var/run/crio
@@ -40,11 +44,11 @@ jobs:
         with:
           go-version: stable
           cache: false
-      - run: sudo hack/github-actions-setup
+      - run: hack/github-actions-setup
       - name: Run CRI-O integration tests (critest=${{ matrix.critest }})
         run: |
-          CRIO_DIR=$(sudo go env GOPATH)/src/github.com/cri-o/cri-o
-          sudo make -C "$CRIO_DIR" all test-binaries
+          CRIO_DIR=$(go env GOPATH)/src/github.com/cri-o/cri-o
+          make -C "$CRIO_DIR" all test-binaries
           # skip seccomp tests because they have permission denied issues in a container and accept signed image as they don't use conmon
           # skip crio-wipe tests as they test cri-o's wipe functionality, not conmon
           sudo rm -f "$CRIO_DIR"/test/seccomp*.bats "$CRIO_DIR"/test/image.bats "$CRIO_DIR"/test/policy.bats "$CRIO_DIR"/test/crio-wipe.bats

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,13 +33,12 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        go-version: [stable, oldstable]
         critest: [0, 1]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: stable
           cache: false
       - run: sudo hack/github-actions-setup
       - name: Run CRI-O integration tests (critest=${{ matrix.critest }})

--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -176,6 +176,9 @@ install_bats() {
     rm -rf bats-core
     mkdir -p ~/.parallel
     touch ~/.parallel/will-cite
+    # The test suites run bats under sudo, so root needs it as well.
+    sudo mkdir -p /root/.parallel
+    sudo touch /root/.parallel/will-cite
 }
 
 # install_critools installs the cri-tools version given as $1. It is called

--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -163,6 +163,9 @@ install_packages() {
 }
 
 install_conmon() {
+    # Build as ourselves, install as root: nothing here needs to be built by
+    # root, and doing so only leaves root-owned objects in the work tree.
+    make bin/conmon
     sudo make install.bin
     conmon --version
 }
@@ -189,9 +192,13 @@ install_critools() {
 
     git clone --depth 1 --branch "$version" $URL
     pushd cri-tools
-    sudo -E PATH="$PATH" make BINDIR=/usr/bin install
+    make critest crictl
+    # Only the install needs root. It needs our PATH as well: the Makefile
+    # asks `go env` for the directory of the binaries it is about to install,
+    # and root's secure_path may well have no go in it.
+    sudo env "PATH=$PATH" make BINDIR=/usr/bin install
     popd
-    sudo rm -rf cri-tools
+    rm -rf cri-tools
     sudo critest --version
     sudo crictl --version
 }
@@ -228,10 +235,11 @@ install_crun() {
     git clone --depth 1 --branch "${VERSIONS["crun"]}" https://github.com/containers/crun
     pushd crun
     ./autogen.sh
-    ./configure
-    sudo make -j "$(nproc)" install prefix=/usr
+    ./configure --prefix=/usr
+    make -j "$(nproc)"
+    sudo make install
     popd
-    sudo rm -rf crun
+    rm -rf crun
 
     crun --version
 }


### PR DESCRIPTION
`hack/github-actions-setup` builds runc, cri-tools, ginkgo and cri-o, and every one of them wants a newer Go than the runner image ships, so every one of them downloads a toolchain of its own:

```
+ make RUNC_BUILDTAGS=-libpathrs
go: downloading go1.25.0 (linux/amd64)
...
go: github.com/onsi/ginkgo/v2@v2.32.1 requires go >= 1.25.0; switching to go1.25.13
go: downloading go1.25.13 (linux/amd64)
...
+ sudo -E PATH=... make BINDIR=/usr/bin install
go: downloading go1.26.2 (linux/amd64)
```

Downloads for nothing, and that many more opportunities to hang on a stalled network, which today has been anything but theoretical.

### 1. `ci: drop the oldstable Go matrix arm`

The cri-o job builds all of that twice, once with the current Go and once with the previous one. What that tests is whether cri-o, cri-tools and ginkgo build with an older Go, which is their business, not this repository's -- conmon is C, and the Go used to build the harness around it has no bearing on how conmon behaves. It also costs two of the four cri-o runs, at about forty minutes each.

It is in the way of the second commit, too: `actions/setup-go` sets `GOTOOLCHAIN=local`, so once the script actually uses the Go installed for it, nothing quietly fetches a newer toolchain any more -- the whole point -- and cri-tools wants one:

```
go: go.mod requires go >= 1.26.2 (running go 1.25.13; GOTOOLCHAIN=local)
make: *** [Makefile:101: .../critest] Error 1
```

Keeping the arm would mean putting `GOTOOLCHAIN=auto` back for it, i.e. reintroducing the very downloads this PR removes, to keep testing something this repository does not care about.

This one goes first so that CI is green at every commit of the series rather than only at the end.

### 2. `ci: don't run the setup script as root`

**The cri-o job runs `setup-go` today and downloads all three toolchains anyway.** The script runs under `sudo`, which resets `PATH` to its `secure_path`; the Go from setup-go lives in the tool cache, which is not on that path, so root picks up the image's own older Go and the action was for nothing.

The obvious patch is `sudo -E env "PATH=$PATH" hack/github-actions-setup`, and that is what this PR did at first. Then it turned out that the script does not need root at all: every privileged step in it already asks for it on its own --

```bash
prepare_system()      sudo systemctl / sudo sysctl / sudo modprobe / sudo iptables
install_packages()    apt_get() { sudo timeout ... apt-get ... }
install_conmon()      sudo make install.bin
install_bats()        sudo ./install.sh /usr/local
install_runc()        make ... ; sudo install -D -m0755 runc /usr/bin/runc
install_cni_plugins() sudo mkdir ... ; sudo tar ...
install_testdeps()    make ... ; sudo cp ... /usr/bin
setup_etc_subid()     echo ... | sudo tee /etc/subuid
```

-- while the builds themselves are plain `make`. So instead of resetting the environment with `sudo` and then carefully putting it back with `sudo -E env "PATH=$PATH"`, this drops the outer `sudo` and lets the script run as the user the Go was installed for. PATH and `GOTOOLCHAIN=local` then simply apply.

That also removes a trap the `-E` version walked straight into. `sudo -E` preserves the environment, `HOME` included, and `GOPATH` is derived from `HOME` -- so the script cloned cri-o into `/home/runner/go` while the test step, which asks for the path with a plain `sudo go env GOPATH`, went looking in `/root/go`:

```
++ go env GOPATH
+ CLONE_PATH=/home/runner/go/src/github.com/cri-o
...
make: *** /root/go/src/github.com/cri-o/cri-o: No such file or directory.  Stop.
```

With no `sudo` on either side the two agree by construction. The test step's `make -C "$CRIO_DIR" all test-binaries` loses its `sudo` for the same reason -- building cri-o does not need root, and building it as root is what left the toolchain downloads in place there as well. The tests themselves still run as root.

Two smaller things come along:

* the `conmon` job gets `setup-go`, which it never had;
* root gets a `~/.parallel/will-cite` of its own, since root is who the suites run bats as. Previously the script created it for whoever ran it, which happened to be root.

### 3. `hack: build the test dependencies as the user, install as root`

The same question, one level down. With the outer `sudo` gone, three steps inside the script still build under sudo:

```bash
install_conmon:   sudo make install.bin
install_crun:     sudo make -j "$(nproc)" install prefix=/usr
install_critools: sudo -E PATH="$PATH" make BINDIR=/usr/bin install
```

Root is needed to put binaries in `/usr`, not to compile them. Compiling as root is what makes the `PATH="$PATH"` in the cri-tools line necessary in the first place -- without it sudo resets PATH to its `secure_path` and cri-tools is built with the image's Go, exactly the problem this PR is about -- and it is why the two build trees below have to be removed with `sudo rm -rf`.

So all three are split into a build and an install, the way `install_runc` has been doing it all along:

```bash
make bin/conmon
sudo make install.bin
```

The install targets depend on the *files* just built, not on phony targets, so nothing is built twice:

* conmon: `install.bin: bin/conmon`, and `bin/conmon` is a real file target -- `make -n install.bin` after a build prints two `install` commands and nothing else;
* cri-tools: `install: $(CRITEST) $(CRICTL)`, and while `critest` and `crictl` are phony (their recipe is `$(MAKE) -B $(CRITEST)`, an unconditional rebuild), `install` does not depend on them but on the files they produce, which have no prerequisites of their own;
* crun: automake's `install` reaches `all-am`, which finds everything up to date.

cri-tools keeps a `PATH` on its install step, for a reason worth spelling out: its Makefile computes the directory of the binaries with

```make
GOARCH ?= $(shell $(GO) env GOARCH)
GOOS   ?= $(shell $(GO) env GOOS)
BUILD_BIN_PATH := $(BUILD_PATH)/bin/$(GOOS)/$(GOARCH)
```

If root's `secure_path` has no `go`, both collapse to empty, the path becomes `build/bin//`, and `make install` sets out to build a binary that is not there instead of installing the one that is. It does have a `go` on today's runner image, but that is not something to depend on.

crun's prefix moves from `make` to `./configure`, where autotools expects it, and the two `sudo rm -rf` become plain `rm -rf`.

Verification is CI itself: the `go: downloading go1.x` lines should be gone from both jobs, setup step and test step alike.
