### PR TITLE
ci: remove the runner image's bundled podman

### DIFF
--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -57,13 +57,18 @@ remove_packages() {
         containernetworking-plugins
 }
 
-# remove_runtimes removes all the pre-installed OCI runtimes, so they can't
-# shadow the ones we install. The runner image ships a static podman bundle in
-# /usr/local/bin (which comes first in PATH) containing its own runc and crun
-# -- notably a crun built without systemd support, which breaks all the cri-o
-# tests -- and docker brings its own /usr/bin/runc.
+# remove_runtimes removes the pre-installed OCI runtimes and podman, so they
+# can't shadow the ones we install. The runner image ships a static podman
+# bundle in /usr/local/bin (which comes first in PATH) with its own runc and
+# crun, all built without systemd support (actions/runner-images#14569): that
+# crun breaks the cri-o tests, and that podman deadlocks in "podman container
+# cleanup". Docker brings its own /usr/bin/runc.
 remove_runtimes() {
     sudo rm -f /usr/{local/,}{s,}bin/{runc,crun}
+    # The bundled podman only: unlike the runtimes it is not reinstalled
+    # below, install_packages having already put Ubuntu's in /usr/bin.
+    sudo rm -f /usr/local/bin/podman
+    podman --version
 }
 
 APT_OPTS=(


### PR DESCRIPTION
The test suite uses podman for real -- `test/setup_suite.bash` pulls the image the test rootfs comes from, and `test/06-exec-exit-status.bats` runs containers with `podman --conmon` -- and the podman it gets is the runner image's static bundle in `/usr/local/bin`, which comes first in PATH (sudo's `secure_path` included). Not the one `install_packages` puts in `/usr/bin`.

That bundle is built without the `systemd` build tag, exactly like its crun, which `remove_runtimes` already deals with. See also actions/runner-images#14569, reporting that container health checks silently do nothing for the same reason.

### It also deadlocks

`podman container cleanup` -- the exit command podman hands to conmon -- wedges with every thread in `futex_wait`:

```
31832  PPID=1      S   do_wait        60s  bin/conmon --api-version 1 -c d2ebb658...
31836  PPID=31832  Sl  futex_do_wait  60s  /usr/local/bin/podman ... --exit-command-arg container --exit-command-arg cleanup
```

conmon is in `wait4()` on the child it was told to run and holds nothing itself -- its fds are the three standard ones, all on `/dev/null`. The wedged podman holds `/var/lib/containers/storage/db.sql` open, and every other podman on the machine then blocks on it: in one of these dumps `podman ps -a` produced no output at all before its own 30 second timeout fired.

This is what makes `integration: exec exit codes work correctly` fail after exactly 60 seconds, and, before this branch's timeouts, what made the whole job hang until it was killed.

### The evidence

Three runs of ten parallel jobs each, run as a matrix with and without this bundle:

| | with the bundle | without it (Ubuntu's podman) |
|---|---|---|
| hangs of this shape | ~14 of 50 | **0 of 50** |

The cleanest of those runs is the last one, taken with #673's pidfile fix in
place, so that the only test failures left were this: two hangs in the bundle
arm, and 10 green out of 10 in the apt arm.

### What this does

Removes `/usr/local/bin/podman` in `remove_runtimes`, leaving the podman from `install_packages`.

Note it removes the bundled one *only*: unlike runc and crun, which the script installs afresh right after, podman is not reinstalled, so the `/usr/{local/,}{s,}bin/` glob the runtimes use would have taken `/usr/bin/podman` with it. `podman --version` is printed afterwards, so which one survived is recorded in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
