### PR TITLE
exec: report a runtime failure to the parent

### DIFF
--- a/src/conmon.c
+++ b/src/conmon.c
@@ -390,8 +390,27 @@ int main(int argc, char *argv[])
 	/* Read the pid so we can wait for the process to exit */
 	_cleanup_free_ char *contents = NULL;
 	if (!g_file_get_contents(opt_container_pid_file, &contents, NULL, &err)) {
-		nwarnf("Failed to read pidfile: %s", err->message);
-		exit(1);
+		/*
+		 * The runtime did not write the pid file, so the process was never started.
+		 * For exec this is the only way to tell "the runtime failed" from "the command
+		 * exited with a non-zero status", as the latter is a legitimate non-zero exit
+		 * of the runtime, checked (and skipped for exec) above. Report the failure to
+		 * the parent, which would otherwise see a successful exec, and pass along
+		 * whatever the runtime has to say about it.
+		 */
+		const char *error_msg = err->message;
+		if (mainfd_stderr >= 0) {
+			g_unix_set_fd_nonblocking(mainfd_stderr, TRUE, NULL);
+			num_read = read(mainfd_stderr, buf, BUF_SIZE - 1);
+			if (num_read > 0) {
+				buf[num_read] = '\0';
+				nwarnf("runtime stderr: %s", buf);
+				error_msg = buf;
+			}
+		}
+		if (sync_pipe_fd >= 0)
+			write_or_close_sync_fd(&sync_pipe_fd, -1, error_msg);
+		nexitf("Failed to read pidfile: %s", err->message);
 	}
 
 	container_pid = atoi(contents);

--- a/test/08-exec.bats
+++ b/test/08-exec.bats
@@ -186,3 +186,27 @@ teardown() {
     assert_json "${output}" =~ '"data": 0'
 }
 
+
+@test "exec: runtime failure is reported to the sync pipe" {
+    start_conmon_with_default_args --log-path "k8s-file:$LOG_PATH"
+    wait_for_runtime_status "$CTR_ID" running
+    start_oci_sync_pipe_reader
+
+    # A process spec the runtime can not start, so it never writes a pidfile.
+    generate_process_spec "true"
+    sed -i 's|"/bin/sh"|"/no/such/binary"|' "$BUNDLE_PATH/process.json"
+
+    start_conmon_with_default_args \
+        --log-path "k8s-file:$LOG_PATH.exec" \
+        --api-version 1 \
+        --exec \
+        --exec-process-spec "${BUNDLE_PATH}/process.json" 6>"$OCI_SYNCPIPE_PATH"
+    wait_for_conmon_exit "$CONMON_PID"
+
+    # The failure has to be reported rather than silently swallowed, and the
+    # report has to carry what the runtime said about it.
+    wait_for_syncpipe_output 1
+    run cat $TEST_TMPDIR/syncpipe-output
+    assert_json "${output}" =~ '"data": -1'
+    assert "${output}" =~ "exec failed"
+}


### PR DESCRIPTION
When the runtime fails to start the exec'd process, it does not write the pid file. Conmon merely warned about that and exited, and since the failing conmon is the daemonized child, its exit status went nowhere: the caller saw the parent exit 0 and got nothing on the sync pipe, so an exec that never ran looked exactly like a successful one.

A non-zero runtime exit status can not be used to tell those apart for exec -- it is also how the exit status of the exec'd command is reported, which is why the existing check skips exec. A missing pid file, on the other hand, means the process was never started.

So report it: write the failure to the sync pipe, together with whatever the runtime printed to its stderr, and exit with an error rather than a warning.

With this, a failing exec produces

```
{"data": -1, "message": "... exec failed: unable to start container process: exec: \"/no/such/binary\": stat /no/such/binary: no such file or directory\n"}
```

instead of silence. A test for that is added.