### PR TITLE
Do not free the string owned by GLib

### DIFF
--- a/src/conn_sock.c
+++ b/src/conn_sock.c
@@ -149,7 +149,7 @@ static void set_socket_buffers(int fd)
 
 char *setup_console_socket(void)
 {
-	_cleanup_free_ const char *tmpdir = g_get_tmp_dir();
+	const char *tmpdir = g_get_tmp_dir();
 
 	char *csname = g_build_filename(tmpdir, "conmon-term.XXXXXX", NULL);
 	/*


### PR DESCRIPTION
`g_get_tmp_dir()` returns a constant owned by GLib and cached in a static variable, which the caller must not free -- but `setup_console_socket` declares it `_cleanup_free_`, so it is freed on return. That leaves GLib's static pointing to freed memory, and the next `g_get_tmp_dir()` in the process hands out a dangling pointer.

It does not bite today, since `setup_console_socket` is called at most once per conmon process, but a use-after-free is a use-after-free.