### PR TITLE
ci: drop the dead JOBS pin

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,8 +50,6 @@ jobs:
           # skip crio-wipe tests as they test cri-o's wipe functionality, not conmon
           sudo rm -f "$CRIO_DIR"/test/seccomp*.bats "$CRIO_DIR"/test/image.bats "$CRIO_DIR"/test/policy.bats "$CRIO_DIR"/test/crio-wipe.bats
           sudo sh -c "cd $CRIO_DIR; RUN_CRITEST=${{ matrix.critest }} ./test/test_runner.sh"
-        env:
-          JOBS: '2'
 
   all-done:
     needs:


### PR DESCRIPTION
cri-o's `test/test_runner.sh` picks the parallelism itself:

```bash
export JOBS=${JOBS:-$(nproc --all)}
```

and this workflow has been overriding it with `JOBS: '2'` ever since dd99302 ("Add CRI-O integration test GitHub action", March 2021). Back then that was not a limit but a fact -- GitHub-hosted runners had exactly two vCPUs, so `2` is what `nproc` would have returned anyway.

**The pin has not applied for almost two years.** 3619051 ("gh actions: call make correctly", October 2024) replaced

```yaml
          sudo -E test/test_runner.sh
```

with

```yaml
          sudo sh -c "cd $CRIO_DIR; RUN_CRITEST=${{ matrix.critest }} ./test/test_runner.sh"
```

Without `-E`, sudo resets the environment, so `JOBS` never reaches the script -- `RUN_CRITEST` survives only because it is passed inline. The job logs agree; the runners have four vCPUs and the suite has been running as

```
++ bats --jobs 4 --tap . --filter-tags !crio:serial
```

So this changes nothing about how the tests run. It removes a setting that pretends to configure something and does not, and leaves the parallelism to follow the hardware, now and whenever the runners grow again.
