### PR TITLE
ci: skip the cri-o tests that do not test conmon

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,6 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
+      # Let the other job finish: these two take about half an hour each, and
+      # one of them failing is no reason to throw the other one's result away.
+      fail-fast: false
       matrix:
         critest: [0, 1]
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,9 +49,51 @@ jobs:
         run: |
           CRIO_DIR=$(go env GOPATH)/src/github.com/cri-o/cri-o
           make -C "$CRIO_DIR" all test-binaries
-          # skip seccomp tests because they have permission denied issues in a container and accept signed image as they don't use conmon
-          # skip crio-wipe tests as they test cri-o's wipe functionality, not conmon
-          sudo rm -f "$CRIO_DIR"/test/seccomp*.bats "$CRIO_DIR"/test/image.bats "$CRIO_DIR"/test/policy.bats "$CRIO_DIR"/test/crio-wipe.bats
+          # These test files do not exercise conmon, so skip them: that is
+          # about a third of the suite's run time.
+          skip=(
+              # images, registries, and the artifacts served from them
+              artifact_additional_stores
+              cert
+              image
+              image_remove
+              image_volume
+              imagefsinfo
+              inspecti
+              namespaced_auth_dir
+              oci_artifacts
+              policy
+              seccomp_oci_artifacts
+              tls_config
+
+              # security profiles: handled by cri-o and the runtime, not conmon
+              apparmor
+              seccomp_notifier
+              seccomp_runtime_handler
+
+              # cri-o's own configuration, status and storage
+              annotation_migration
+              crio-check
+              crio-wipe
+              inject_gomaxprocs
+              profile
+              reload_config
+              reload_system
+              status
+              workloads
+
+              # cri-o's metrics endpoints
+              cri-metrics
+              metrics
+
+              # device and plugin plumbing
+              cdi
+              nri
+          )
+          for t in "${skip[@]}"; do
+              # No -f: a file cri-o renames must fail the job, not be skipped.
+              rm "$CRIO_DIR/test/$t.bats"
+          done
           sudo sh -c "cd $CRIO_DIR; RUN_CRITEST=${{ matrix.critest }} ./test/test_runner.sh"
         env:
           JOBS: '2'


### PR DESCRIPTION
The cri-o suite is the bulk of this workflow: about 40 minutes, against 3 for critest and 5-9 for the setup. It has been trimmed before -- `image`, `policy`, `crio-wipe` and, in intent, `seccomp*` -- but not in a while, and cri-o has grown a lot of tests since.

### Where the time goes

Measured by running the suite with `bats --timing` ([#683](https://github.com/containers/conmon/pull/683)), which puts a duration on every TAP line. 481 tests, 8943 seconds of test time spread over four parallel jobs:

| file | sec | tests | | file | sec | tests |
| --- | ---: | ---: | --- | --- | ---: | ---: |
| ctr | 1500 | 75 | | cdi | 195 | 13 |
| timeout | 1137 | 12 | | seccomp_oci_artifacts | 187 | 11 |
| annotation_migration | 455 | 25 | | conmon_track | 171 | 6 |
| restore | 431 | 15 | | cri-metrics | 167 | 10 |
| pod | 407 | 29 | | nri | 164 | 12 |
| oci_artifacts | 318 | 18 | | cgroups | 149 | 12 |
| reload_config | 264 | 20 | | inject_gomaxprocs | 130 | 9 |
| exec_termination | 253 | 12 | | seccomp_runtime_handler | 113 | 6 |
| apparmor | 238 | **1** | | artifact_additional_stores | 111 | 8 |
| network | 230 | 15 | | ctr_timeout | 108 | 5 |
| ctr_seccomp | 218 | 13 | | status | 106 | 10 |
| workloads | 212 | 16 | | reload_system | 103 | 7 |

### What is dropped

28 files, about 3200 seconds -- a third of the suite -- none of which involve conmon:

* **images, registries and artifacts**: `image`, `image_remove`, `image_volume`, `imagefsinfo`, `inspecti`, `cert`, `tls_config`, `namespaced_auth_dir`, `oci_artifacts`, `artifact_additional_stores`, `seccomp_oci_artifacts`, `policy`
* **security profiles**, which the runtime applies, not conmon: `apparmor` (one test, 238s), `seccomp_notifier` (conmon's seccomp notify support was removed in #671), `seccomp_runtime_handler`
* **cri-o's own configuration, status and storage**: `reload_config`, `reload_system`, `annotation_migration`, `workloads`, `inject_gomaxprocs`, `status`, `crio-check`, `crio-wipe`, `profile`
* **metrics**: `cri-metrics`, `metrics`
* **device and plugin plumbing**: `cdi`, `nri`

Everything that runs containers stays: `ctr`, `pod`, `timeout`, `ctr_timeout`, `exec_*`, `conmon_track`, `restore`, `logs`, `cgroups`, `namespaces`, `network`, `ctr_seccomp`, `devices`, `ctr_userns` and the rest.

### The glob that never worked

```yaml
sudo rm -f "$CRIO_DIR"/test/seccomp*.bats "$CRIO_DIR"/test/image.bats ...
```

Until #678 moved the cri-o tree out of root's home, this removed nothing: the glob is expanded by the shell running the step, as the user, and `$CRIO_DIR` was under `/root`, which that user cannot read. So it matched nothing, was passed through literally, and `rm -f` swallowed it -- which is why `seccomp_oci_artifacts.bats` and `seccomp_runtime_handler.bats` are in the timing table above, 300 seconds of tests we have believed to be off for years. The paths without a glob were removed correctly all along.

So the names are now spelled out, and one that does not exist is an error rather than a no-op: a file cri-o renames should be noticed, not quietly let back into the run.

Rebased on top of #678, so the removal needs no `sudo` at all -- the tests are ours now.
