### PR TITLE
Moar test fixes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,10 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: stable
+          # TODO: switch back to stable once cri-o vendors golang.org/x/net
+          # v0.55.0 or newer; until then it does not build with go 1.27.
+          # See https://github.com/cri-o/cri-o/pull/10103#issuecomment-5400108050
+          go-version: '1.26'
           cache: false
       - run: hack/github-actions-setup
       - name: Run conmon integration tests
@@ -45,7 +48,10 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: stable
+          # TODO: switch back to stable once cri-o vendors golang.org/x/net
+          # v0.55.0 or newer; until then it does not build with go 1.27.
+          # See https://github.com/cri-o/cri-o/pull/10103#issuecomment-5400108050
+          go-version: '1.26'
           cache: false
       - run: hack/github-actions-setup
       - name: Run CRI-O integration tests (critest=${{ matrix.critest }})

--- a/test/10-ctrl.bats
+++ b/test/10-ctrl.bats
@@ -173,6 +173,11 @@ test_resize_command_ok() {
     wait_for_runtime_status "$CTR_ID" running
     local main_conmon_pid=$CONMON_PID
 
+    # The container being up does not mean its first line has been logged
+    # yet, and rotating before it is written leaves it in the new log rather
+    # than the rotated one, which is what the test checks for below.
+    wait_for_log_line "$LOG_PATH" "before rotation"
+
     # The control message should rotate the log
     echo "2 1 1" > ${CTL_PATH}
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -543,6 +543,22 @@ _file_has_lines() {
     [ -e "$1" ] && [ "$(wc -l <"$1")" -ge "$2" ]
 }
 
+_file_has_line() {
+    [ -e "$1" ] && grep -q -- "$2" "$1"
+}
+
+# wait_for_log_line waits until the pattern given as $2 shows up in the log
+# file $1. Conmon writes the log as the container's output arrives, so a test
+# acting on a line right after starting the container is racing it.
+wait_for_log_line() {
+    local file=$1
+    local pattern=$2
+    local how_long=${3:-10}
+
+    retry "$how_long" 0.1 _file_has_line "$file" "$pattern" ||
+        die "timed out waiting for '$pattern' in $file: $(cat "$file" 2>&1)"
+}
+
 # Generic helper function to create pipe and read from it.
 _start_pipe_reader() {
     local pipe_path=$1

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -387,6 +387,34 @@ assert_stderr_contains() {
     fi
 }
 
+# Usage: retry <how_long> <interval> <command ...>
+#
+# Runs the command until it succeeds, for at most <how_long> seconds, waiting
+# <interval> seconds between the attempts. Returns non-zero if the command
+# never succeeded, leaving it to the caller to report that: the caller is the
+# one that knows what it was waiting for.
+retry() {
+    local how_long=$1
+    local interval=$2
+    shift 2
+
+    local t1=$((SECONDS + how_long))
+    while [ "$SECONDS" -lt "$t1" ]; do
+        if "$@"; then
+            return 0
+        fi
+        sleep "$interval"
+    done
+
+    return 1
+}
+
+_runtime_status_is() {
+    run_runtime state "$1"
+    echo "$output"
+    expr "$output" : ".*status\": \"$2" >/dev/null
+}
+
 # Helper function to wait until "runc state $cid" returns expected status.
 wait_for_runtime_status() {
     local cid=$1
@@ -396,17 +424,12 @@ wait_for_runtime_status() {
     # loaded CI runner.
     local how_long=30
 
-    t1=$(expr $SECONDS + $how_long)
-    while [ $SECONDS -lt $t1 ]; do
-        run_runtime state "$cid"
-        echo "$output"
-        if expr "$output" : ".*status\": \"$expected_status"; then
-            return
-        fi
-        sleep 0.5
-    done
+    retry "$how_long" 0.5 _runtime_status_is "$cid" "$expected_status" ||
+        die "timed out waiting for '$expected_status' from $cid"
+}
 
-    die "timed out waiting for '$expected_status' from $cid"
+_pid_is_gone() {
+    ! kill -0 "$1" 2>/dev/null
 }
 
 # Helper function to wait until the conmon process $pid has exited.
@@ -417,13 +440,8 @@ wait_for_conmon_exit() {
     local pid=$1
     local how_long=${2:-10}
 
-    local t1=$((SECONDS + how_long))
-    while [ "$SECONDS" -lt "$t1" ]; do
-        kill -0 "$pid" 2>/dev/null || return 0
-        sleep 0.1
-    done
-
-    die "timed out waiting for conmon (pid $pid) to exit"
+    retry "$how_long" 0.1 _pid_is_gone "$pid" ||
+        die "timed out waiting for conmon (pid $pid) to exit"
 }
 
 # _run_conmon runs conmon with the default arguments plus the ones given,
@@ -517,15 +535,12 @@ wait_for_syncpipe_output() {
     local how_long=${2:-10}
     local file="$TEST_TMPDIR/syncpipe-output"
 
-    local t1=$((SECONDS + how_long))
-    while [ "$SECONDS" -lt "$t1" ]; do
-        if [ -e "$file" ] && [ "$(wc -l <"$file")" -ge "$how_many" ]; then
-            return 0
-        fi
-        sleep 0.1
-    done
+    retry "$how_long" 0.1 _file_has_lines "$file" "$how_many" ||
+        die "timed out waiting for $how_many line(s) in $file: $(cat "$file" 2>&1)"
+}
 
-    die "timed out waiting for $how_many line(s) in $file: $(cat "$file" 2>&1)"
+_file_has_lines() {
+    [ -e "$1" ] && [ "$(wc -l <"$1")" -ge "$2" ]
 }
 
 # Generic helper function to create pipe and read from it.


### PR DESCRIPTION
The coverage job hit this on #684, which touches nothing but the cri-o test selection:

```
not ok 120 ctrl: rotate logs with --log-rotate
  in test file test/10-ctrl.bats, line 192
  `assert "${output}" =~ "before rotation"' failed
```

### The race

`ctrl: rotate logs with --log-rotate` starts a container that writes `before rotation`, sends `2 1 1` to the control fifo to rotate the log, and then checks that the line is in the rotated file `$LOG_PATH.1` and that what comes after is in the new `$LOG_PATH`.

The test waits for the container to be *running* before rotating, but that says nothing about conmon having written the first line to the log yet. Lose that race and the rotation moves a log that does not contain the line, `before rotation` lands in the fresh log along with `after rotation`, and `$LOG_PATH.1` is there -- so the `assert_file_exists` above passes -- but empty. The coverage job is the slowest one, which is where this turns up.

So the test now waits for the line to be logged before rotating.

### The helper

While adding the fourth "poll until X" helper to `test_helper.bash`, the loop -- deadline from `$SECONDS`, check, sleep, `die` -- was written out three times already. It is now

```bash
retry <how_long> <interval> <command ...>
```

which returns non-zero instead of dying: it does not know what it was waiting for, the callers do, and they keep their own messages. `wait_for_runtime_status`, `wait_for_conmon_exit` and `wait_for_syncpipe_output` are converted to it, and the new `wait_for_log_line` uses it too.

No functional change from the conversion, other than the status check in `wait_for_runtime_status` no longer printing `expr`'s match count into the test log.

Ran the full suite locally: 120/120.

### The unrelated CI breakage

Also here, since the cri-o job was red for a reason of its own: go 1.27 (which `go-version: stable` started resolving to) does not build cri-o main.

In `golang.org/x/net` v0.54.0, which cri-o vendors, `http2` switches to a thin wrapper around `net/http` under go 1.27 (`server.go` is `//go:build !(go1.27 && !http2legacy)`), and `http2.TrailerPrefix` -- used by the vendored grpc -- is only defined in the non-wrapped build:

```
vendor/google.golang.org/grpc/internal/transport/handler_server.go:271:18: undefined: http2.TrailerPrefix
```

Upstream fixes this by vendoring x/net v0.55.0, which moves `TrailerPrefix` into a file built either way; see https://github.com/cri-o/cri-o/pull/10103#issuecomment-5400108050. Until that lands, go is pinned to 1.26 here.
