### PR TITLE
ci: fix zizmor findings, add zizmor workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,36 @@
+# This is deliberately a separate workflow -- so that it still runs when
+# another workflow file is broken.
+name: actionlint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+      - release-*
+  pull_request:
+  workflow_dispatch:
+permissions: {}
+
+# Cancel a PR's older runs when it is pushed to again. github.head_ref is set
+# for pull_request events only, so pushes to main and tags fall back to the
+# unique run_id and are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v7
+    - uses: devops-actions/actionlint@ec02b36684b2f574f1d219ad0a43b082e46bf3e4 # v0.1.13
+
+  all-done:
+    needs:
+      - actionlint
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "All jobs completed"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - uses: devops-actions/actionlint@ec02b36684b2f574f1d219ad0a43b082e46bf3e4 # v0.1.13

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -26,6 +26,8 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - uses: devops-actions/actionlint@ec02b36684b2f574f1d219ad0a43b082e46bf3e4 # v0.1.13
 
   all-done:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           # TODO: switch back to stable once cri-o vendors golang.org/x/net
           # v0.55.0 or newer; until then it does not build with go 1.27.
@@ -47,10 +47,10 @@ jobs:
       matrix:
         critest: [0, 1]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           # TODO: switch back to stable once cri-o vendors golang.org/x/net
           # v0.55.0 or newer; until then it does not build with go 1.27.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v7
         with:
           # TODO: switch back to stable once cri-o vendors golang.org/x/net
@@ -46,6 +48,8 @@ jobs:
         critest: [0, 1]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v7
         with:
           # TODO: switch back to stable once cri-o vendors golang.org/x/net

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,7 +26,7 @@ jobs:
           - name: s390x
             target: default-s390x.nix
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install podman
@@ -49,7 +49,7 @@ jobs:
              nix-build nix/$TARGET && \
              nix-store -qR --include-outputs \$(nix-instantiate nix/$TARGET) | grep -v conmon | cachix push conmon && \
              cp -R result/bin ."
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: conmon-${{ matrix.name }}
           path: bin/conmon

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,6 +27,8 @@ jobs:
             target: default-s390x.nix
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install podman
         run: |
           sudo apt-get update

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Check C code formatting
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Build with meson

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,8 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Check C code formatting
       run: |
         sudo apt-get update
@@ -35,6 +37,8 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Build with meson
       run: |
         sudo apt-get update

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,42 @@
+# This is deliberately a separate workflow -- so that it still runs when
+# another workflow file is broken.
+name: zizmor
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+      - release-*
+  pull_request:
+  workflow_dispatch:
+permissions: {}
+
+# Cancel a PR's older runs when it is pushed to again. github.head_ref is set
+# for pull_request events only, so pushes to main and tags fall back to the
+# unique run_id and are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+      with:
+        # Report findings by failing this job, rather than uploading them to
+        # the repository's security tab.
+        advanced-security: false
+
+  all-done:
+    needs:
+      - zizmor
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "All jobs completed"


### PR DESCRIPTION
Based on #686 (the first commit here is that PR); please merge that one first.

Run [zizmor](https://docs.zizmor.sh/) over the workflow files, fix everything it reports, and add a CI job so it stays fixed.

The findings, one commit each:

* **artipacked** (7): `actions/checkout` leaves the GitHub token in `.git/config` by default. None of the workflows use those credentials, so set `persist-credentials: false`.
* **unpinned-uses** (10): actions were referenced by mutable tags. Pin them to commit hashes, with the version in a trailing comment. Renovate keeps these updated.

The `zizmor` workflow is a separate file, for the same reason as `actionlint`: it still runs when another workflow file is broken. `advanced-security: false` is set so that findings fail the job instead of only appearing in the security tab.

Two findings are only reported by `--persona=pedantic` and are left alone:

* `template-injection` on `integration.yml` for `${{ matrix.critest }}` — the matrix is defined statically in the same file, so it is not attacker-controllable.
* `concurrency-limits` on `static.yml` — it only runs on tags and `workflow_dispatch`.

Verified locally with zizmor 1.22.0 (`--persona=regular`): no findings. `actionlint` is also clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)