### PR TITLE
ci: attach the static binaries to the release

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -54,6 +54,45 @@ jobs:
           name: conmon-${{ matrix.name }}
           path: bin/conmon
 
+  upload:
+    # Attach the binaries built above to the release for this tag, so that
+    # cutting a release does not mean downloading five artifacts by hand.
+    # Manual runs have no tag to attach to, hence the condition.
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - static-binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    env:
+      # This job does not check the repository out, so gh has no git remote
+      # to infer the repository from and has to be told.
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: conmon-*
+          path: artifacts
+      - name: Rename the binaries after their architecture
+        run: |
+          mkdir assets
+          for d in artifacts/conmon-*; do
+              mv "$d/conmon" "assets/conmon.${d#artifacts/conmon-}"
+          done
+          ls -l assets
+      - name: Upload the binaries to the ${{ github.ref_name }} release
+        run: |
+          # A release created from the web UI already exists by the time the
+          # tag build finishes; a tag pushed on its own has none, so make a
+          # draft for the release notes to be written into and published --
+          # publishing is what triggers packit's downstream sync.
+          gh release view "$TAG" >/dev/null ||
+              gh release create "$TAG" --draft --title "$TAG" --generate-notes
+          gh release upload "$TAG" assets/* --clobber
+
   all-done:
     needs:
       - static-binary


### PR DESCRIPTION
Pushing a `v*` tag already builds the static binaries for all five architectures, but they are left as workflow artifacts: cutting a release means downloading five of them by hand and uploading them again, which is how `conmon.amd64` & co. ended up on v2.2.1. Do it in the workflow instead.

If no release exists for the tag yet — a tag pushed on its own, rather than one created along with a release from the web UI — the job creates a draft, so that the release notes can be written before anything is announced. Publishing the release is what triggers packit's downstream sync to Fedora and CentOS Stream, so it matters that the workflow does not publish anything by itself.

### Testing

The `upload` job only runs on a `v*` tag, so a PR run does not exercise it at all. It was tested by pushing a scratch tag to my fork, with the cachix push dropped for that run since a fork has no `CACHIX_AUTH_TOKEN` (reading from the cache still works). The tag, the branch and the draft release have since been deleted.

The draft was created, the five assets were attached under the same names v2.2.1 uses, and the downloaded `conmon.amd64` is a stripped, statically linked ELF that runs and reports its version.