### PR TITLE
nix: stop stamping release binaries as dirty, and check that they are not

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -49,6 +49,31 @@ jobs:
              nix-build nix/$TARGET && \
              nix-store -qR --include-outputs \$(nix-instantiate nix/$TARGET) | grep -v conmon | cachix push conmon && \
              cp -R result/bin ."
+      - name: Check the version stamped into the binary
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          # The binaries for the other architectures cannot be run here, so
+          # read the string the build baked in rather than asking conmon for
+          # it. A mismatch means the Makefile's git-vars saw something other
+          # than a clean checkout of this commit -- most likely a build step
+          # that modified a tracked file and made the tree look dirty.
+          want_version="conmon version $(cat VERSION)"
+          want_commit="commit: $SHA"
+          got_version=$(strings bin/conmon | grep -m1 '^conmon version ' || true)
+          got_commit=$(strings bin/conmon | grep -m1 '^commit: ' || true)
+          rc=0
+          if [ "$got_version" != "$want_version" ]; then
+              echo "want: $want_version"
+              echo "got:  $got_version"
+              rc=1
+          fi
+          if [ "$got_commit" != "$want_commit" ]; then
+              echo "want: $want_commit"
+              echo "got:  $got_commit"
+              rc=1
+          fi
+          exit $rc
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: conmon-${{ matrix.name }}

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -29,7 +29,6 @@ with pkgs; stdenv.mkDerivation rec {
     ${lib.optionalString (!enableSystemd) "export DISABLE_SYSTEMD=1"}
   '';
   buildPhase = ''
-    patchShebangs .
     make
   '';
   installPhase = ''


### PR DESCRIPTION
The static binaries attached to a release report a dirty tree:

```console
$ conmon.amd64 --version
conmon version 2.2.1
commit: c8cc2c4db27531bd4e084ce7857f73cd21ee639d-dirty
```

### The cause

The source handed to nix keeps its `.git` on purpose: `gitMinimal` is in `nativeBuildInputs` so that the Makefile's `git-vars` target can stamp the real commit into the binary. Part of what `git-vars` does is decide whether to append `-dirty`, by looking at `git status --porcelain --untracked-files=no`.

`patchShebangs` rewrites the interpreter line of every script it finds, which here means tracked files. Running it before `make` therefore guarantees that `git status` is never empty and that every build is stamped dirty. Instrumenting the build phase, reading the status the same way the Makefile does, shows exactly that:

```
MAKESHELL=[ M hack/get_ci_vm.sh  M hack/github-actions-setup  M test/run-tests.sh]
```

Nothing needs it. conmon is a C program, the build runs no script from the tree, and `installPhase` installs a single binary; scripts that do end up in an output are handled by the `fixupPhase` nixpkgs runs anyway.

### The check

Nothing would have caught this, and nothing would catch it coming back, since the version string is only ever read by whoever runs the binary. The second commit checks it in the workflow that builds it. Four of the five binaries cannot be run on the runner, so the check reads the string out of the binary instead of asking conmon for it, which works the same way for every architecture.

It fails on a dirty stamp, and equally on a commit that is not the one being built — including the `unknown` that `git-vars` falls back to when git does not work at all.

### Testing

Built `nix/default.nix` in the `nixos/nix:2.15.0` image, the same way `static.yml` does, before and after the change. Before: `commit: <sha>-dirty`. After:

```console
$ ./conmon --version
conmon version 2.2.1
commit: 946b260af0834846aa89b586da94a29095647178
```

which matches HEAD exactly. The binary is otherwise unchanged: still a stripped, statically linked ELF, byte-for-byte the same size.

The check itself was run against three real binaries — the fixed one, and the dirty v2.2.1 and test-build ones — and passes and fails as it should, including when handed the wrong commit. It was then run for real by pushing a scratch tag to my fork, where all five architectures passed it, `strings` reading the string out of the ppc64le, riscv64 and s390x binaries just as well as the native ones. The tag and branch have since been deleted.