### PR TITLE
ci: revert "ci: pin go to 1.26"

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,10 +26,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          # TODO: switch back to stable once cri-o vendors golang.org/x/net
-          # v0.55.0 or newer; until then it does not build with go 1.27.
-          # See https://github.com/cri-o/cri-o/pull/10103#issuecomment-5400108050
-          go-version: '1.26'
+          go-version: stable
           cache: false
       - run: hack/github-actions-setup
       - name: Run conmon integration tests
@@ -52,10 +49,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          # TODO: switch back to stable once cri-o vendors golang.org/x/net
-          # v0.55.0 or newer; until then it does not build with go 1.27.
-          # See https://github.com/cri-o/cri-o/pull/10103#issuecomment-5400108050
-          go-version: '1.26'
+          go-version: stable
           cache: false
       - run: hack/github-actions-setup
       - name: Run CRI-O integration tests (critest=${{ matrix.critest }})


### PR DESCRIPTION
Since https://github.com/cri-o/cri-o/pull/10103 is now merged, we can go back to using "stable" go version.

This reverts commit d9c7a3c62da1e6bb3ccf3307bcda35056bafe0fb (part of PR #685).