### PR TITLE
ci: speed up the integration setup step

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,6 +31,22 @@ jobs:
           # See https://github.com/cri-o/cri-o/pull/10103#issuecomment-5400108050
           go-version: '1.26'
           cache: false
+      # The setup script builds runc, ginkgo, critest and crictl from source,
+      # and the cri-o job builds cri-o itself; all of that is Go, and all of it
+      # recompiles the standard library and the vendored trees from scratch on
+      # every run. setup-go's own cache is keyed on a go.sum this repository
+      # does not have, hence caching GOCACHE and the module cache by hand.
+      #
+      # The key follows the dependency versions pinned in the setup script, so
+      # a bump gets a fresh cache; restore-keys then still seeds it from the
+      # previous one, which keeps that first build incremental.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.job }}-${{ hashFiles('hack/github-actions-setup') }}
+          restore-keys: ${{ runner.os }}-go-${{ github.job }}-
       - run: hack/github-actions-setup
       - name: Run conmon integration tests
         run: |
@@ -57,6 +73,22 @@ jobs:
           # See https://github.com/cri-o/cri-o/pull/10103#issuecomment-5400108050
           go-version: '1.26'
           cache: false
+      # The setup script builds runc, ginkgo, critest and crictl from source,
+      # and the cri-o job builds cri-o itself; all of that is Go, and all of it
+      # recompiles the standard library and the vendored trees from scratch on
+      # every run. setup-go's own cache is keyed on a go.sum this repository
+      # does not have, hence caching GOCACHE and the module cache by hand.
+      #
+      # The key follows the dependency versions pinned in the setup script, so
+      # a bump gets a fresh cache; restore-keys then still seeds it from the
+      # previous one, which keeps that first build incremental.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.job }}-${{ hashFiles('hack/github-actions-setup') }}
+          restore-keys: ${{ runner.os }}-go-${{ github.job }}-
       - run: hack/github-actions-setup
       - name: Run CRI-O integration tests (critest=${{ matrix.critest }})
         run: |

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+# cache-poisoning fires on integration.yml because a tag push can trigger it,
+# and a poisoned cache could then end up inside a published artifact. That
+# workflow only runs tests and publishes nothing -- the release build lives in
+# static.yml, which does not cache -- so the finding does not apply here.
+rules:
+  cache-poisoning:
+    ignore:
+      - integration.yml

--- a/hack/github-actions-setup
+++ b/hack/github-actions-setup
@@ -172,9 +172,9 @@ install_conmon() {
 }
 
 install_bats() {
-    git clone https://github.com/bats-core/bats-core
+    git clone --depth 1 --branch "${VERSIONS["bats"]}" \
+        https://github.com/bats-core/bats-core
     pushd bats-core
-    git checkout "${VERSIONS["bats"]}"
     sudo ./install.sh /usr/local
     popd
     rm -rf bats-core
@@ -264,7 +264,10 @@ install_testdeps() {
     pushd "$CLONE_PATH"
 
     URL=https://github.com/cri-o/cri-o
-    git clone $URL
+    # Only the default branch's tree is used (scripts/versions, the test
+    # suites, and the vendored ginkgo), so there is no need to fetch the
+    # history of a repository this size.
+    git clone --depth 1 $URL
     pushd cri-o
     make "$(pwd)"/build/bin/ginkgo
     sudo cp build/bin/ginkgo /usr/bin


### PR DESCRIPTION
Two changes:

- **Shallow-clone cri-o and bats.** The cri-o clone is the only one in the script without a depth limit, and it is the largest repository involved. Only the default branch's tree is used (`scripts/versions`, the test suites, and the vendored ginkgo), so the history is fetched and discarded every run. bats is switched from clone-then-checkout to fetching the tag directly.

- **Cache GOCACHE and the module cache.** The script builds runc, ginkgo, critest and crictl from source, and the cri-o job builds cri-o itself; every run recompiles the standard library and the vendored trees from scratch. `setup-go`'s own cache is keyed on a `go.sum` this repository does not have, hence caching the two directories by hand. The key follows the versions pinned in the setup script, with `restore-keys` so that a version bump still gets an incremental first build, and includes the job name so the two jobs do not race for one cache entry.

  `.github/zizmor.yml` comes with it: zizmor's `cache-poisoning` audit fires because a tag push can trigger this workflow, and a poisoned cache could then reach a published artifact. This workflow publishes nothing -- the release build is in `static.yml`, which does not cache -- so the finding is ignored for this file only.

A third commit, oversubscribing the cores for the cri-o suite, has been dropped: cri-o/cri-o#10285 makes `test/test_runner.sh` default `JOBS` to `nproc * 2` itself.

Detailed measurements are in the comments below.
